### PR TITLE
Add `netsblox host` to connect to multiple hosts (eg, dev, cloud)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,9 +1933,11 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "confy",
+ "derive_more",
  "exitcode",
  "futures-util",
  "inquire",
+ "lazy_static",
  "netsblox-api",
  "reqwest",
  "serde 1.0.136",

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -50,7 +50,7 @@ async fn check_response(response: Response) -> Result<Response, error::Error> {
 }
 
 pub type Token = String;
-pub async fn login(cfg: &mut Config, credentials: &LoginRequest) -> Result<(), error::Error> {
+pub async fn login(mut cfg: Config, credentials: &LoginRequest) -> Result<Config, error::Error> {
     let client = reqwest::Client::new();
     let response = client
         .post(format!("{}/users/login", cfg.url))
@@ -70,7 +70,7 @@ pub async fn login(cfg: &mut Config, credentials: &LoginRequest) -> Result<(), e
 
     cfg.username = Some(response.text().await.unwrap());
     cfg.token = Some(token);
-    Ok(())
+    Ok(cfg)
 }
 
 #[derive(Serialize)]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,3 +20,5 @@ netsblox-api = { path = "../api", version = "0.1.0" }
 futures-util = "0.3.19"
 exitcode = "1.1.2"
 xmlparser = "0.13.5"
+lazy_static = "1.4.0"
+derive_more = "0.99.17"

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -1,0 +1,75 @@
+use std::collections::HashMap;
+
+use lazy_static::lazy_static;
+use netsblox_api::{self, common::AppId};
+use serde::{Deserialize, Serialize};
+
+lazy_static! {
+    static ref DEFAULT_HOST: HostConfig = HostConfig::default();
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+pub(crate) struct HostConfig {
+    pub(crate) url: String,
+    pub(crate) username: Option<String>,
+    pub(crate) token: Option<String>,
+}
+
+impl Default for HostConfig {
+    fn default() -> Self {
+        Self {
+            url: "https://cloud.netsblox.org".to_owned(),
+            username: None,
+            token: None,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+pub(crate) struct Config {
+    pub(crate) current_host: String,
+    pub(crate) hosts: HashMap<String, HostConfig>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        let current_host = String::from("cloud");
+        let hosts = HashMap::from([(current_host.clone(), HostConfig::default())]);
+
+        Self {
+            current_host,
+            hosts,
+        }
+    }
+}
+
+impl Config {
+    pub(crate) fn host(&self) -> &HostConfig {
+        self.hosts.get(&self.current_host).unwrap_or(&DEFAULT_HOST) // TODO: add a warning log?
+    }
+
+    pub(crate) fn set_credentials(&mut self, api_cfg: &netsblox_api::Config) {
+        if let Some(cfg) = self.hosts.get_mut(&self.current_host) {
+            cfg.username = api_cfg.username.to_owned();
+            cfg.token = api_cfg.token.to_owned();
+        }
+    }
+
+    pub(crate) fn clear_credentials(&mut self) {
+        if let Some(cfg) = self.hosts.get_mut(&self.current_host) {
+            cfg.username = None;
+            cfg.token = None;
+        }
+    }
+}
+
+impl From<HostConfig> for netsblox_api::Config {
+    fn from(config: HostConfig) -> netsblox_api::Config {
+        netsblox_api::Config {
+            app_id: Some(AppId::new("NetsBloxCLI")),
+            url: config.url,
+            username: config.username,
+            token: config.token,
+        }
+    }
+}

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -1,0 +1,15 @@
+use derive_more::Display;
+
+#[derive(Debug, Display)]
+pub enum Error {
+    #[display(fmt = "{}", _0)]
+    APIError(netsblox_api::error::Error),
+    #[display(fmt = "Host not found.")]
+    HostNotFoundError,
+}
+
+impl From<netsblox_api::error::Error> for Error {
+    fn from(api_err: netsblox_api::error::Error) -> Error {
+        Error::APIError(api_err)
+    }
+}


### PR DESCRIPTION
This adds another subcomment, `host` to the netsblox CLI. This allows people to add/remove/list/use NetsBlox cloud instances connected to from the CLI. That is, the CLI now maintains a list of different hosts along with the username/token used to connect to each one of them. The idea is that then you can jump btwn a local dev deployment and the production environment with just a `netsblox host use dev` or `netsblox host use cloud`, etc.

Here is the help info for the `netsblox host` command:
```
netsblox-host 
Connect to different instances of NetsBlox cloud

USAGE:
    netsblox host <SUBCOMMAND>

OPTIONS:
    -h, --help    Print help information

SUBCOMMANDS:
    add       Add a new NetsBlox cloud instance
    help      Print this message or the help of the given subcommand(s)
    list      List all known cloud instances
    remove    Remove an existing NetsBlox cloud instance
    use       Use the given host for subsequent commands

```
Listing the hosts will also show the current account logged in for each. For example:
```
cloud   https://cloud.netsblox.org      brian
dev     http://localhost:8080   admin

```
