### PR TITLE
Block messages to group members from unknown users. Close #13

### DIFF
--- a/crates/cloud/config/default.toml
+++ b/crates/cloud/config/default.toml
@@ -2,10 +2,10 @@ address = "0.0.0.0:7777"
 public_url = "http://127.0.0.1:7777"
 #login_url = "https://login.netsblox.org"
 
-[admin]
-username = "admin"
-password = "somePassword"
-email = "admin@netsblox.org"
+# [admin]
+# username = "admin"
+# password = "somePassword"
+# email = "admin@netsblox.org"
 
 [database]
 url = "mongodb://127.0.0.1:27017/"

--- a/crates/cloud/config/default.toml
+++ b/crates/cloud/config/default.toml
@@ -2,10 +2,10 @@ address = "0.0.0.0:7777"
 public_url = "http://127.0.0.1:7777"
 #login_url = "https://login.netsblox.org"
 
-# [admin]
-# username = "admin"
-# password = "somePassword"
-# email = "admin@netsblox.org"
+[admin]
+username = "admin"
+password = "somePassword"
+email = "admin@netsblox.org"
 
 [database]
 url = "mongodb://127.0.0.1:27017/"

--- a/crates/cloud/src/app_data/mod.rs
+++ b/crates/cloud/src/app_data/mod.rs
@@ -9,21 +9,19 @@ use lazy_static::lazy_static;
 use lettre::message::{Mailbox, MultiPart};
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::{Address, Message, SmtpTransport, Transport};
-use log::{info, warn};
+use log::{error, info, warn};
 use lru::LruCache;
 use mongodb::bson::{doc, DateTime, Document};
-<<<<<<< Updated upstream
-use mongodb::options::{FindOneAndUpdateOptions, IndexOptions, ReturnDocument};
-use netsblox_cloud_common::api::{FriendInvite, FriendLinkState};
-=======
 use mongodb::options::{FindOneAndUpdateOptions, FindOptions, IndexOptions, ReturnDocument};
->>>>>>> Stashed changes
+use netsblox_cloud_common::api::{FriendInvite, FriendLinkState, GroupId};
 use rusoto_core::credential::StaticProvider;
 use rusoto_core::Region;
 use serde::{Deserialize, Serialize};
+use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
+use tokio::sync::RwLock as AsyncRwLock;
 use uuid::Uuid;
 
 use crate::common::api::{RoleData, SaveState};
@@ -36,7 +34,6 @@ use crate::config::Settings;
 use crate::errors::{InternalError, UserError};
 use crate::libraries;
 use crate::network::topology::{self, SetStorage, TopologyActor};
-use crate::users::get_user_role;
 use actix::{Actor, Addr};
 use futures::TryStreamExt;
 use mongodb::{Client, Collection, IndexModel};
@@ -48,8 +45,12 @@ use rusoto_s3::{
 // This is lazy_static to ensure it is shared between threads
 // TODO: it would be nice to be able to configure the cache size from the settings
 lazy_static! {
-    static ref MEMBERSHIP_CACHE: Arc<RwLock<LruCache<String, bool>>> =
-        Arc::new(RwLock::new(LruCache::new(1000)));
+    static ref MEMBERSHIP_CACHE: Arc<AsyncRwLock<LruCache<String, bool>>> =
+        Arc::new(AsyncRwLock::new(LruCache::new(1000)));
+}
+lazy_static! {
+    static ref ADMIN_CACHE: Arc<AsyncRwLock<LruCache<String, bool>>> =
+        Arc::new(AsyncRwLock::new(LruCache::new(1000)));
 }
 
 lazy_static! {
@@ -675,50 +676,83 @@ impl AppData {
         self.on_room_changed(updated_metadata.clone());
         Ok(updated_metadata)
     }
+
     // Membership queries (cached)
-    pub async fn keep_members(
-        &self,
-        usernames: impl Iterator<Item = Option<&String>>,
-    ) -> Result<impl Iterator<Item = &String>, UserError> {
-        let mut cache = MEMBERSHIP_CACHE.write().unwrap();
+    pub async fn keep_members(&self, usernames: HashSet<String>) -> Result<Vec<String>, UserError> {
+        let cache = MEMBERSHIP_CACHE.write().await;
         let unknown_users: Vec<_> = usernames
-            .filter(|name_opt| name_opt.map(|name| !cache.contains(name)).unwrap_or(false))
+            .iter()
+            .filter(|name| !cache.contains(*name))
             .collect();
         drop(cache); // don't hold the lock over the upcoming async boundary
 
         let unknown_count = unknown_users.len() as i64;
-        let opts = FindOptions::builder().limit(Some(unknown_count)).build();
-        let query = doc! {"$or":
-            unknown_users.into_iter().map(|name| doc!{"username": name}).collect::<Vec<_>>()
-        };
-        let users = self
-            .users
-            .find(query, opts)
-            .await
-            .map_err(InternalError::DatabaseConnectionError)?
-            .try_collect::<Vec<_>>()
-            .await
-            .map_err(InternalError::DatabaseConnectionError)?;
+        if unknown_count > 0 {
+            let opts = FindOptions::builder().limit(Some(unknown_count)).build();
+            let query = doc! {"$or":
+                unknown_users.into_iter().map(|name| doc!{"username": name}).collect::<Vec<_>>()
+            };
+            let users = self
+                .users
+                .find(query, opts)
+                .await
+                .map_err(InternalError::DatabaseConnectionError)?
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(InternalError::DatabaseConnectionError)?;
 
-        let mut cache = MEMBERSHIP_CACHE.write().unwrap();
-        users.into_iter().for_each(|usr| {
-            cache.put(usr.username, usr.group_id.is_some());
-        });
-        // TODO: check the cache?
-        // TODO: check membership
-        // TODO: I think the logic ahead is a little problematic and needs to be checked out...
-        usernames.filter(|name_opt| {
-            name_opt
-                .map(|name| {
-                    // Althought unlikely, it's possible that the entries
-                    // have been invalidated from the cache while looking up
-                    // the unknown users. In this case, we will be conservative
-                    // and just assume they are members.
-                    let is_member = cache.get(name).unwrap_or(&true);
-                    *is_member
+            let mut cache = MEMBERSHIP_CACHE.write().await;
+            users.into_iter().for_each(|usr| {
+                cache.put(usr.username, usr.group_id.is_some());
+            });
+        }
+
+        let mut cache = MEMBERSHIP_CACHE.write().await;
+        let members: Vec<_> = usernames
+            .into_iter()
+            .filter(|name| {
+                // Althought unlikely, it's possible that the entries
+                // have been invalidated from the cache while looking up
+                // the unknown users. In this case, we will be conservative
+                // and just assume they are members.
+                let is_member = cache.get(name).unwrap_or(&true);
+                *is_member
+            })
+            .collect();
+
+        Ok(members)
+    }
+
+    // Cached admin-checking
+    pub async fn is_admin(&self, username: &str) -> bool {
+        let cache = ADMIN_CACHE.write().await;
+        let needs_lookup = !cache.contains(username);
+        drop(cache); // don't hold the lock during the database query
+
+        if needs_lookup {
+            let query = doc! {"username": &username};
+            let is_admin = self
+                .users
+                .find_one(query, None)
+                .await
+                .map_err(|err| {
+                    error!("Database error: {:?}", err);
+                    InternalError::DatabaseConnectionError(err)
                 })
-                .unwrap_or(true)
-        })
+                .ok()
+                .flatten()
+                .map(|user| matches!(user.role, UserRole::Admin))
+                .unwrap_or(false);
+
+            let mut cache = ADMIN_CACHE.write().await;
+            cache.put(username.to_owned(), is_admin);
+        }
+
+        let mut cache = ADMIN_CACHE.write().await;
+        cache
+            .get(username)
+            .map(|is_admin| is_admin.to_owned())
+            .unwrap_or(false)
     }
 
     // Friend-related features
@@ -728,7 +762,16 @@ impl AppData {
     }
 
     async fn lookup_friends(&self, username: &str) -> Result<Vec<String>, UserError> {
-        let is_universal_friend = matches!(get_user_role(self, username).await?, UserRole::Admin);
+        let query = doc! {"username": &username};
+        let user = self
+            .users
+            .find_one(query, None)
+            .await
+            .map_err(InternalError::DatabaseConnectionError)?
+            .ok_or(UserError::UserNotFoundError)?;
+
+        let is_universal_friend = matches!(user.role, UserRole::Admin);
+
         let friend_names: Vec<_> = if is_universal_friend {
             self.users
                 .find(doc! {}, None)
@@ -741,7 +784,36 @@ impl AppData {
                 .map(|user| user.username)
                 .filter(|name| name != username)
                 .collect()
+        } else if let Some(group_id) = user.group_id {
+            // get owner + all members
+            let query = doc! {"id": &group_id};
+            let group = self
+                .groups
+                .find_one(query, None)
+                .await
+                .map_err(InternalError::DatabaseConnectionError)?
+                .ok_or(UserError::GroupNotFoundError)?;
+            let members = self.lookup_members(std::iter::once(&group_id)).await?;
+
+            std::iter::once(group.owner)
+                .chain(members.into_iter().map(|user| user.username))
+                .collect()
         } else {
+            // look up:
+            //   - members of any group we own
+            //   - accepted friend requests/links
+            let query = doc! {"owner": &username};
+            let groups = self
+                .groups
+                .find(query, None)
+                .await
+                .map_err(InternalError::DatabaseConnectionError)?
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(InternalError::DatabaseConnectionError)?;
+            let group_ids = groups.into_iter().map(|group| group.id);
+            let members = self.lookup_members(group_ids).await?;
+
             let query = doc! {"$or": [
                 {"sender": &username, "state": FriendLinkState::APPROVED},
                 {"recipient": &username, "state": FriendLinkState::APPROVED}
@@ -765,10 +837,46 @@ impl AppData {
                         l.sender
                     }
                 })
+                .chain(members.into_iter().map(|user| user.username))
                 .collect()
         };
 
         Ok(friend_names)
+    }
+
+    async fn lookup_members<T>(
+        &self,
+        group_ids: impl Iterator<Item = T>,
+    ) -> Result<Vec<User>, UserError>
+    where
+        T: Borrow<GroupId>,
+    {
+        let member_queries: Vec<_> = group_ids.map(|id| doc! {"groupId": id.borrow()}).collect();
+        let query = doc! {"$or": member_queries};
+
+        let members = self
+            .users
+            .find(query, None)
+            .await
+            .map_err(InternalError::DatabaseConnectionError)?
+            .try_collect::<Vec<_>>()
+            .await
+            .map_err(InternalError::DatabaseConnectionError)?;
+
+        Ok(members)
+    }
+
+    /// Invalidate the relevant cached values when a user is added or removed
+    /// from a group
+    pub async fn group_members_updated(&self, group_id: &GroupId) {
+        if let Ok(members) = self.lookup_members(std::iter::once(group_id)).await {
+            let mut cache = FRIEND_CACHE.write().unwrap();
+            members.into_iter().for_each(|user| {
+                cache.pop(&user.username);
+            });
+        } else {
+            error!("Error occurred while retrieving members for {}", group_id);
+        }
     }
 
     pub async fn get_friends(&self, username: &str) -> Result<Vec<String>, UserError> {

--- a/crates/cloud/src/network/topology/network.rs
+++ b/crates/cloud/src/network/topology/network.rs
@@ -286,15 +286,29 @@ impl Topology {
         .into_iter()
         .flatten();
 
+<<<<<<< Updated upstream
         // TODO: if the recipient is in a group, ensure the sender is a friend
         recipients.clone().for_each(|client| {
             client.addr.do_send(message.clone()).unwrap();
         });
 
         // maybe record the message
+=======
+>>>>>>> Stashed changes
         if let Some(app) = &self.app_data {
+            // check if the message is allowed
+            // TODO: get user membership
+            // TODO: get user membership
+            let recipients = self.valid_recipients(&app, &msg.sender, recipients).await;
+            // TODO: make method for getting all the cached users?
+
+            recipients.iter().for_each(|client| {
+                client.addr.do_send(message.clone()).unwrap();
+            });
+
+            // maybe record the message
             let project_ids: Vec<_> = recipients
-                .clone()
+                .iter()
                 .map(|client| &client.id)
                 .chain(std::iter::once(&msg.sender))
                 .filter_map(|client_id| match self.get_client_state(client_id) {
@@ -321,6 +335,7 @@ impl Topology {
 
             let source = self.get_client_state(&msg.sender).unwrap();
             let recipients = recipients
+                .into_iter()
                 .filter_map(|client| self.get_client_state(&client.id))
                 .map(|state| state.to_owned())
                 .collect::<Vec<_>>();
@@ -345,6 +360,19 @@ impl Topology {
                     .unwrap();
             }
         }
+    }
+
+    async fn valid_recipients(
+        &self,
+        app: &AppData,
+        sender: &ClientId,
+        recipients: impl Iterator<Item = &Client>,
+    ) -> Vec<&Client> {
+        let usernames = recipients.map(|rcp| self.usernames.get(&rcp.id));
+        let sender = self.usernames.get(sender);
+        // TODO: check if the recipients are group members
+        // TODO: if so, check that the sender is a friend
+        todo!()
     }
 
     fn has_client(&self, id: &ClientId) -> bool {

--- a/crates/cloud/src/network/topology/network.rs
+++ b/crates/cloud/src/network/topology/network.rs
@@ -362,20 +362,12 @@ impl Topology {
         recipients: Vec<&'a Client>,
     ) -> Vec<&'a Client> {
         let sender = self.usernames.get(sender);
-
-        // TODO: for each recipient,
-        //   - if he/she is a member, allow if the sender is a friend
-        //   - else, allow
         let recipient_names: HashSet<_> = recipients
             .iter()
             .filter_map(|rcp| self.usernames.get(&rcp.id))
             .cloned()
             .collect();
-        let members = app
-            // TODO: remove dupes from recipient list
-            .keep_members(recipient_names)
-            .await
-            .unwrap_or_default();
+        let members = app.keep_members(recipient_names).await.unwrap_or_default();
 
         let deny_list: HashSet<_> = if let Some(sender) = sender {
             if app.is_admin(sender).await {

--- a/crates/cloud/src/network/topology/network.rs
+++ b/crates/cloud/src/network/topology/network.rs
@@ -381,7 +381,7 @@ impl Topology {
                 }))
                 .await
                 .into_iter()
-                .filter_map(|(rec_name, is_friend)| if is_friend { Some(rec_name) } else { None })
+                .filter_map(|(rec_name, is_friend)| if !is_friend { Some(rec_name) } else { None })
                 .collect()
             }
         } else {


### PR DESCRIPTION
This PR adds support for blocking messages sent from outside a group in (with the exception of admins). All checks cache data so database queries only happen on the first request; otherwise, performance would be a pretty serious concern.