### PR TITLE
Add support for --only using the migration CLI. Close #65

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,7 +2000,9 @@ dependencies = [
 name = "netsblox-migrate"
 version = "0.4.0"
 dependencies = [
+ "clap",
  "config",
+ "derive_more",
  "futures",
  "indicatif",
  "mongodb",
@@ -2893,9 +2895,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "indexmap",
  "itoa 1.0.1",

--- a/crates/migrate/Cargo.toml
+++ b/crates/migrate/Cargo.toml
@@ -15,5 +15,7 @@ passwords = "3.1.8"
 futures = "0.3.0"
 rusoto_core = "0.47.0"
 rusoto_s3 = "0.47.0"
+derive_more = "0.99.17"
 config = "0.11.0"
 indicatif = "0.17"
+clap = { version = "3.0.13", features = ["derive"] }

--- a/crates/migrate/src/main.rs
+++ b/crates/migrate/src/main.rs
@@ -1,12 +1,14 @@
 mod config;
 mod origin;
 
-use std::env;
+use std::str::FromStr;
 use std::time::Duration;
 use std::{collections::HashMap, thread};
 
 use crate::config::Config;
+use clap::Parser;
 use cloud::api::{PublishState, SaveState};
+use derive_more::{Display, Error};
 use futures::{future::join_all, stream::StreamExt, TryStreamExt};
 use indicatif::ProgressBar;
 use mongodb::{
@@ -18,195 +20,62 @@ use netsblox_cloud_common as cloud;
 use rusoto_core::{credential::StaticProvider, Region};
 use rusoto_s3::{GetObjectRequest, PutObjectRequest, S3Client, S3};
 
+#[derive(Debug)]
+enum Migration {
+    Libraries,
+    Users,
+    Projects,
+    BannedAccounts,
+}
+
+#[derive(Debug, Display, Error)]
+#[display(fmt = "Unable to parse user role. Expected admin, moderator, or user.")]
+pub struct MigrationError;
+
+impl FromStr for Migration {
+    type Err = MigrationError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "libraries" => Ok(Migration::Libraries),
+            "users" => Ok(Migration::Users),
+            "projects" => Ok(Migration::Projects),
+            "banned-accounts" | "banned-accts" => Ok(Migration::BannedAccounts),
+            _ => Err(MigrationError),
+        }
+    }
+}
+
+#[derive(Parser, Debug)]
+struct Args {
+    /// Path to configuration defining source, dst databases, s3, etc
+    config_path: String,
+    /// Only migrate users, projects, or libraries
+    #[clap(long)]
+    only: Option<Migration>,
+}
+
 #[tokio::main]
 async fn main() {
-    let mut args: Vec<_> = env::args().collect();
-    let usage_msg = format!("Usage: {} <config>", &args[0]);
-    assert!(args.len() == 2, "{}", &usage_msg);
-    let config_path = args.pop().unwrap();
-    let config = Config::load(&config_path).unwrap();
+    let args = Args::parse();
 
+    let config = Config::load(&args.config_path).unwrap();
     let src_db = connect_db(&config.source.database.url).await;
     let dst_db = connect_db(&config.target.database.url).await;
 
-    // Convert users
-    let src_users = src_db.collection::<origin::User>("users");
-    let dst_users = dst_db.collection::<cloud::User>("users");
-    let count = src_users
-        .estimated_document_count(None)
-        .await
-        .expect("Unable to estimate document count for users");
-    let progress = ProgressBar::new(count);
-    progress.println("Migrating users...");
-    let mut cursor = src_users
-        .find(None, None)
-        .await
-        .expect("Unable to fetch users");
-
-    while let Some(user) = cursor.next().await {
-        let new_user: cloud::User = user.expect("Unable to retrieve user").into();
-        let query = doc! {"username": &new_user.username};
-        let update = doc! {"$setOnInsert": &new_user};
-        let opts = UpdateOptions::builder().upsert(true).build();
-        dst_users
-            .update_one(query, update, opts)
-            .await
-            .unwrap_or_else(|_err| panic!("Unable to update username: {}", &new_user.username));
-
-        progress.inc(1);
-    }
-    progress.println("User migration complete.");
-    progress.finish();
-
-    drop(src_users);
-
-    // migrate groups
-    let src_groups = src_db.collection::<origin::Group>("groups");
-    let dst_groups = dst_db.collection::<cloud::Group>("groups");
-    let count = src_groups
-        .estimated_document_count(None)
-        .await
-        .expect("Unable to estimate document count for groups");
-    let progress = ProgressBar::new(count);
-    progress.println("Migrating groups...");
-
-    let query = doc! {};
-    let mut cursor = src_groups
-        .find(query, None)
-        .await
-        .expect("Unable to fetch groups");
-
-    while let Some(group) = cursor.next().await {
-        let group = group.expect("Unable to retrieve group");
-        if let Some(usernames) = group.members.clone() {
-            for name in usernames {
-                let query = doc! {"username": &name};
-                let update = doc! {
-                    "$set": {
-                        "groupId": &group.id.to_string()
-                    }
-                };
-
-                dst_users
-                    .update_one(query, update, None)
-                    .await
-                    .unwrap_or_else(|_err| panic!("Unable to set group for {}", &name));
-            }
+    if let Some(migration) = args.only {
+        match migration {
+            Migration::Users => migrate_users(&src_db, &dst_db).await,
+            Migration::Libraries => migrate_libraries(&src_db, &dst_db).await,
+            Migration::Projects => migrate_projects(&config, &src_db, &dst_db).await,
+            Migration::BannedAccounts => migrate_banned_accts(&src_db, &dst_db).await,
         }
-
-        let new_group: cloud::Group = group.into();
-        let query = doc! {"id": &new_group.id};
-        let update = doc! {"$setOnInsert": &new_group};
-        dst_groups
-            .update_one(query, update, None)
-            .await
-            .unwrap_or_else(|_err| panic!("Unable to update group: {}", &new_group.id));
-        progress.inc(1);
+    } else {
+        // migrate everything
+        migrate_users(&src_db, &dst_db).await;
+        migrate_libraries(&src_db, &dst_db).await;
+        migrate_banned_accts(&src_db, &dst_db).await;
+        migrate_projects(&config, &src_db, &dst_db).await;
     }
-    progress.println("Group migration complete.");
-    progress.finish();
-
-    drop(src_groups);
-    drop(dst_groups);
-
-    // Convert libraries
-    let src_libraries = src_db.collection::<origin::Library>("libraries");
-    let dst_libraries = dst_db.collection::<cloud::Library>("libraries");
-
-    let count = src_libraries
-        .estimated_document_count(None)
-        .await
-        .expect("Unable to estimate document count for libraries");
-    let progress = ProgressBar::new(count);
-    progress.println("Migrating libraries...");
-    let query = doc! {};
-    let mut cursor = src_libraries.find(query, None).await.unwrap();
-
-    while let Some(library) = cursor.next().await {
-        let library = library.unwrap();
-        let new_lib: cloud::Library = library.into();
-        let query = doc! {
-            "owner": &new_lib.owner,
-            "name": &new_lib.name
-        };
-        let update = doc! {"$setOnInsert": &new_lib};
-        dst_libraries.update_one(query, update, None).await.unwrap();
-        progress.inc(1);
-    }
-    progress.println("Library migration complete.");
-    progress.finish();
-
-    drop(src_libraries);
-    drop(dst_libraries);
-
-    // Convert banned accounts
-    let src_bans = src_db.collection::<origin::BannedAccount>("bannedAccounts");
-    let dst_bans = dst_db.collection::<cloud::BannedAccount>("bannedAccounts");
-
-    let count = src_bans
-        .estimated_document_count(None)
-        .await
-        .expect("Unable to estimate document count for banned accounts");
-    let progress = ProgressBar::new(count);
-    progress.println("Migrating banned accounts...");
-    let query = doc! {};
-    let mut cursor = src_bans.find(query, None).await.unwrap();
-
-    while let Some(account) = cursor.next().await {
-        let account = account.unwrap();
-        let new_acct: cloud::BannedAccount = account.into();
-        let query = doc! {
-            "username": &new_acct.username,
-        };
-        let update = doc! {"$setOnInsert": &new_acct};
-        dst_bans.update_one(query, update, None).await.unwrap();
-
-        progress.inc(1);
-    }
-    progress.println("Banned account migration complete.");
-    progress.finish();
-
-    drop(src_bans);
-    drop(dst_bans);
-
-    // Convert projects
-    let src_projects = src_db.collection::<origin::ProjectMetadata>("projects");
-    let dst_projects = dst_db.collection::<cloud::ProjectMetadata>("projects");
-    let src_s3 = get_s3_client(&config.source.s3);
-    let dst_s3 = get_s3_client(&config.target.s3);
-
-    let query = doc! {"transient": false}; // FIXME: what if transient isn't set
-    let count = src_projects
-        .count_documents(query.clone(), None)
-        .await
-        .expect("Unable to estimate document count for banned accounts");
-    let progress = ProgressBar::new(count);
-    progress.println("Migrating projects...");
-
-    let mut cursor = src_projects.find(query, None).await.unwrap();
-
-    while let Some(metadata) = cursor.next().await {
-        let metadata = metadata.unwrap();
-        let query = doc! {
-            "owner": &metadata.owner,
-            "name": &metadata.name,
-        };
-        let exists = dst_projects.find_one(query, None).await.unwrap().is_some();
-        if !exists {
-            let project = download(&src_s3, &config.source.s3.bucket, metadata).await;
-            let metadata = upload(&dst_s3, &config.target.s3.bucket, project).await;
-            dst_projects.insert_one(&metadata, None).await.unwrap();
-            // throttle to about 2k req/sec to avoid 503 errors from AWS
-            thread::sleep(Duration::from_millis(10));
-        }
-        progress.inc(1);
-    }
-    progress.println("Project migration complete.");
-    progress.finish();
-    drop(src_s3);
-    drop(src_projects);
-    drop(dst_s3);
-    drop(dst_projects);
 }
 
 fn get_s3_client(config: &config::S3) -> S3Client {
@@ -390,4 +259,178 @@ async fn download_s3(client: &S3Client, bucket: &str, key: &str) -> String {
         .unwrap();
 
     String::from_utf8(byte_str).unwrap()
+}
+
+async fn migrate_users(src_db: &Database, dst_db: &Database) {
+    let src_users = src_db.collection::<origin::User>("users");
+    let dst_users = dst_db.collection::<cloud::User>("users");
+    let count = src_users
+        .estimated_document_count(None)
+        .await
+        .expect("Unable to estimate document count for users");
+    let progress = ProgressBar::new(count);
+    progress.println("Migrating users...");
+    let mut cursor = src_users
+        .find(None, None)
+        .await
+        .expect("Unable to fetch users");
+
+    while let Some(user) = cursor.next().await {
+        let new_user: cloud::User = user.expect("Unable to retrieve user").into();
+        let query = doc! {"username": &new_user.username};
+        let update = doc! {"$setOnInsert": &new_user};
+        let opts = UpdateOptions::builder().upsert(true).build();
+        dst_users
+            .update_one(query, update, opts)
+            .await
+            .unwrap_or_else(|_err| panic!("Unable to update username: {}", &new_user.username));
+
+        progress.inc(1);
+    }
+    progress.println("User migration complete.");
+    progress.finish();
+
+    // migrate groups
+    let src_groups = src_db.collection::<origin::Group>("groups");
+    let dst_groups = dst_db.collection::<cloud::Group>("groups");
+    let count = src_groups
+        .estimated_document_count(None)
+        .await
+        .expect("Unable to estimate document count for groups");
+    let progress = ProgressBar::new(count);
+    progress.println("Migrating groups...");
+
+    let query = doc! {};
+    let mut cursor = src_groups
+        .find(query, None)
+        .await
+        .expect("Unable to fetch groups");
+
+    while let Some(group) = cursor.next().await {
+        let group = group.expect("Unable to retrieve group");
+        if let Some(usernames) = group.members.clone() {
+            for name in usernames {
+                let query = doc! {"username": &name};
+                let update = doc! {
+                    "$set": {
+                        "groupId": &group.id.to_string()
+                    }
+                };
+
+                dst_users
+                    .update_one(query, update, None)
+                    .await
+                    .unwrap_or_else(|_err| panic!("Unable to set group for {}", &name));
+            }
+        }
+
+        let new_group: cloud::Group = group.into();
+        let query = doc! {"id": &new_group.id};
+        let update = doc! {"$setOnInsert": &new_group};
+        dst_groups
+            .update_one(query, update, None)
+            .await
+            .unwrap_or_else(|_err| panic!("Unable to update group: {}", &new_group.id));
+        progress.inc(1);
+    }
+    progress.println("Group migration complete.");
+    progress.finish();
+
+    drop(src_groups);
+    drop(dst_groups);
+}
+
+async fn migrate_libraries(src_db: &Database, dst_db: &Database) {
+    let src_libraries = src_db.collection::<origin::Library>("libraries");
+    let dst_libraries = dst_db.collection::<cloud::Library>("libraries");
+
+    let count = src_libraries
+        .estimated_document_count(None)
+        .await
+        .expect("Unable to estimate document count for libraries");
+    let progress = ProgressBar::new(count);
+    progress.println("Migrating libraries...");
+    let query = doc! {};
+    let mut cursor = src_libraries.find(query, None).await.unwrap();
+
+    while let Some(library) = cursor.next().await {
+        let library = library.unwrap();
+        let new_lib: cloud::Library = library.into();
+        let query = doc! {
+            "owner": &new_lib.owner,
+            "name": &new_lib.name
+        };
+        let update = doc! {"$setOnInsert": &new_lib};
+        dst_libraries.update_one(query, update, None).await.unwrap();
+        progress.inc(1);
+    }
+    progress.println("Library migration complete.");
+    progress.finish();
+
+    drop(src_libraries);
+    drop(dst_libraries);
+}
+
+async fn migrate_banned_accts(src_db: &Database, dst_db: &Database) {
+    let src_bans = src_db.collection::<origin::BannedAccount>("bannedAccounts");
+    let dst_bans = dst_db.collection::<cloud::BannedAccount>("bannedAccounts");
+
+    let count = src_bans
+        .estimated_document_count(None)
+        .await
+        .expect("Unable to estimate document count for banned accounts");
+    let progress = ProgressBar::new(count);
+    progress.println("Migrating banned accounts...");
+    let query = doc! {};
+    let mut cursor = src_bans.find(query, None).await.unwrap();
+
+    while let Some(account) = cursor.next().await {
+        let account = account.unwrap();
+        let new_acct: cloud::BannedAccount = account.into();
+        let query = doc! {
+            "username": &new_acct.username,
+        };
+        let update = doc! {"$setOnInsert": &new_acct};
+        dst_bans.update_one(query, update, None).await.unwrap();
+
+        progress.inc(1);
+    }
+    progress.println("Banned account migration complete.");
+    progress.finish();
+}
+
+async fn migrate_projects(config: &Config, src_db: &Database, dst_db: &Database) {
+    let src_projects = src_db.collection::<origin::ProjectMetadata>("projects");
+    let dst_projects = dst_db.collection::<cloud::ProjectMetadata>("projects");
+    let src_s3 = get_s3_client(&config.source.s3);
+    let dst_s3 = get_s3_client(&config.target.s3);
+
+    let query = doc! {"transient": false}; // FIXME: what if transient isn't set
+    let count = src_projects
+        .count_documents(query.clone(), None)
+        .await
+        .expect("Unable to estimate document count for banned accounts");
+    let progress = ProgressBar::new(count);
+    progress.println("Migrating projects...");
+
+    let mut cursor = src_projects.find(query, None).await.unwrap();
+
+    while let Some(metadata) = cursor.next().await {
+        let metadata = metadata.unwrap();
+        let query = doc! {
+            "owner": &metadata.owner,
+            "name": &metadata.name,
+        };
+        let exists = dst_projects.find_one(query, None).await.unwrap().is_some();
+        if !exists {
+            let project = download(&src_s3, &config.source.s3.bucket, metadata).await;
+            let metadata = upload(&dst_s3, &config.target.s3.bucket, project).await;
+            dst_projects.insert_one(&metadata, None).await.unwrap();
+            // throttle to about 2k req/sec to avoid 503 errors from AWS
+            thread::sleep(Duration::from_millis(10));
+        }
+        progress.inc(1);
+    }
+    progress.println("Project migration complete.");
+    progress.finish();
 }


### PR DESCRIPTION
This adds support for `--only` from the CLI to specify individual migrations to run such as "projects", "users", "banned-accounts", or "libraries"
