### PR TITLE
Copy default configs to docker container

### DIFF
--- a/docker/Dockerfile.cloud
+++ b/docker/Dockerfile.cloud
@@ -6,4 +6,5 @@ RUN cargo install --path crates/cloud --locked
 FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y libssl1.1 ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/netsblox-cloud /usr/local/bin/netsblox-cloud
+COPY ./crates/cloud/config/ /config/
 CMD ["netsblox-cloud"]


### PR DESCRIPTION
This PR copies the default configs to the docker image. Previously, a config needed to be mounted but this allows us to more easily use the layered config building on top of the default. This makes the deployment less brittle.