### PR TITLE
Switch XYZActions to all use refs to relevant fields from AppData

### DIFF
--- a/crates/cloud/src/app_data/mod.rs
+++ b/crates/cloud/src/app_data/mod.rs
@@ -54,7 +54,6 @@ pub struct AppData {
     pub(crate) users: Collection<User>,
     pub(crate) banned_accounts: Collection<BannedAccount>,
     friends: Collection<FriendLink>,
-    // TODO: make a "cached collection type"?
     pub(crate) project_metadata: Collection<ProjectMetadata>,
     pub(crate) libraries: Collection<Library>,
     pub(crate) authorized_services: Collection<AuthorizedServiceHost>,
@@ -526,6 +525,87 @@ impl AppData {
         .await
     }
 
+    // get resource actions (eg, libraries, users, etc)
+    pub(crate) fn to_library_actions(&self) -> LibraryActions {
+        LibraryActions::new(&self.libraries)
+    }
+
+    pub(crate) fn to_project_actions(&self) -> ProjectActions {
+        ProjectActions::new(
+            &self.project_metadata,
+            &self.project_cache,
+            &self.network,
+            &self.bucket,
+            &self.s3,
+        )
+    }
+
+    pub(crate) fn to_group_actions(&self) -> GroupActions {
+        GroupActions::new(&self.groups, &self.users)
+    }
+
+    // TODO: can we pass references instead of cloning everything?
+    pub(crate) fn to_friend_actions(&self) -> FriendActions {
+        FriendActions::new(
+            &self.friends,
+            &self.friend_cache,
+            &self.users,
+            &self.groups,
+            &self.network,
+        )
+    }
+
+    pub(crate) fn to_collab_invite_actions(&self) -> CollaborationInviteActions {
+        CollaborationInviteActions::new(
+            &self.collab_invites,
+            &self.project_metadata,
+            &self.project_cache,
+            &self.network,
+        )
+    }
+
+    pub(crate) fn to_network_actions(&self) -> NetworkActions {
+        NetworkActions::new(
+            &self.project_metadata,
+            &self.project_cache,
+            &self.network,
+            &self.occupant_invites,
+            &self.recorded_messages,
+        )
+    }
+
+    pub(crate) fn to_settings_actions(&self) -> SettingsActions {
+        SettingsActions::new(&self.users, &self.groups)
+    }
+
+    pub(crate) fn to_oauth_actions(&self) -> OAuthActions {
+        OAuthActions::new(&self.oauth_clients, &self.oauth_tokens, &self.oauth_codes)
+    }
+
+    pub(crate) fn to_user_actions(&self) -> UserActions {
+        let data = UserActionData {
+            users: &self.users,
+            banned_accounts: &self.banned_accounts,
+            password_tokens: &self.password_tokens,
+            metrics: &self.metrics,
+
+            project_cache: &self.project_cache,
+            project_metadata: &self.project_metadata,
+            network: &self.network,
+
+            friend_cache: &self.friend_cache,
+
+            mailer: &self.mailer,
+            sender: &self.sender,
+            public_url: &self.settings.public_url,
+        };
+        UserActions::new(data)
+    }
+
+    pub(crate) fn to_host_actions(&self) -> HostActions {
+        HostActions::new(&self.authorized_services)
+    }
+
     #[cfg(test)]
     pub(crate) async fn drop_all_data(&self) -> Result<(), InternalError> {
         let bucket = &self.settings.s3.bucket;
@@ -542,135 +622,6 @@ impl AppData {
         }
 
         Ok(())
-    }
-}
-
-impl From<actix_web::web::Data<AppData>> for ProjectActions {
-    fn from(app: actix_web::web::Data<AppData>) -> ProjectActions {
-        ProjectActions::new(
-            app.project_metadata.clone(),
-            app.project_cache.clone(),
-            app.network.clone(),
-            app.bucket.clone(),
-            app.s3.clone(),
-        )
-    }
-}
-
-// TODO: replace this with a macro
-impl From<AppData> for ProjectActions {
-    fn from(app: AppData) -> ProjectActions {
-        ProjectActions::new(
-            app.project_metadata.clone(),
-            app.project_cache.clone(),
-            app.network.clone(),
-            app.bucket.clone(),
-            app.s3,
-        )
-    }
-}
-
-// TODO: can we pass references instead of cloning everything?
-impl From<actix_web::web::Data<AppData>> for FriendActions {
-    fn from(app: actix_web::web::Data<AppData>) -> FriendActions {
-        FriendActions::new(
-            app.friends.clone(),
-            app.friend_cache.clone(),
-            app.users.clone(),
-            app.groups.clone(),
-            app.network.clone(),
-        )
-    }
-}
-
-impl From<AppData> for FriendActions {
-    fn from(app: AppData) -> FriendActions {
-        FriendActions::new(
-            app.friends.clone(),
-            app.friend_cache.clone(),
-            app.users.clone(),
-            app.groups.clone(),
-            app.network,
-        )
-    }
-}
-
-impl From<actix_web::web::Data<AppData>> for CollaborationInviteActions {
-    fn from(app: actix_web::web::Data<AppData>) -> CollaborationInviteActions {
-        CollaborationInviteActions::new(
-            app.collab_invites.clone(),
-            app.project_metadata.clone(),
-            app.project_cache.clone(),
-            app.network.clone(),
-        )
-    }
-}
-
-impl From<actix_web::web::Data<AppData>> for NetworkActions {
-    fn from(app: actix_web::web::Data<AppData>) -> NetworkActions {
-        NetworkActions::new(
-            app.project_metadata.clone(),
-            app.project_cache.clone(),
-            app.network.clone(),
-            app.occupant_invites.clone(),
-            app.recorded_messages.clone(),
-        )
-    }
-}
-
-impl From<actix_web::web::Data<AppData>> for GroupActions {
-    fn from(app: actix_web::web::Data<AppData>) -> GroupActions {
-        GroupActions::new(app.groups.clone(), app.users.clone())
-    }
-}
-
-impl From<actix_web::web::Data<AppData>> for SettingsActions {
-    fn from(app: actix_web::web::Data<AppData>) -> SettingsActions {
-        SettingsActions::new(app.users.clone(), app.groups.clone())
-    }
-}
-
-impl From<actix_web::web::Data<AppData>> for OAuthActions {
-    fn from(app: actix_web::web::Data<AppData>) -> OAuthActions {
-        OAuthActions::new(
-            app.oauth_clients.clone(),
-            app.oauth_tokens.clone(),
-            app.oauth_codes.clone(),
-        )
-    }
-}
-
-impl From<actix_web::web::Data<AppData>> for LibraryActions {
-    fn from(app: actix_web::web::Data<AppData>) -> LibraryActions {
-        LibraryActions::new(app.libraries.clone())
-    }
-}
-
-impl From<actix_web::web::Data<AppData>> for UserActions {
-    fn from(app: actix_web::web::Data<AppData>) -> UserActions {
-        let data = UserActionData {
-            users: app.users.clone(),
-            banned_accounts: app.banned_accounts.clone(),
-            password_tokens: app.password_tokens.clone(),
-            metrics: app.metrics.clone(),
-
-            project_cache: app.project_cache.clone(),
-            project_metadata: app.project_metadata.clone(),
-            network: app.network.clone(),
-
-            friend_cache: app.friend_cache.clone(),
-
-            mailer: app.mailer.clone(),
-            sender: app.sender.clone(),
-            public_url: app.settings.public_url.clone(),
-        };
-        UserActions::new(data)
-    }
-}
-
-impl From<actix_web::web::Data<AppData>> for HostActions {
-    fn from(app: actix_web::web::Data<AppData>) -> HostActions {
-        HostActions::new(app.authorized_services.clone())
     }
 }
 

--- a/crates/cloud/src/app_data/mod.rs
+++ b/crates/cloud/src/app_data/mod.rs
@@ -526,11 +526,11 @@ impl AppData {
     }
 
     // get resource actions (eg, libraries, users, etc)
-    pub(crate) fn to_library_actions(&self) -> LibraryActions {
+    pub(crate) fn as_library_actions(&self) -> LibraryActions {
         LibraryActions::new(&self.libraries)
     }
 
-    pub(crate) fn to_project_actions(&self) -> ProjectActions {
+    pub(crate) fn as_project_actions(&self) -> ProjectActions {
         ProjectActions::new(
             &self.project_metadata,
             &self.project_cache,
@@ -540,12 +540,11 @@ impl AppData {
         )
     }
 
-    pub(crate) fn to_group_actions(&self) -> GroupActions {
+    pub(crate) fn as_group_actions(&self) -> GroupActions {
         GroupActions::new(&self.groups, &self.users)
     }
 
-    // TODO: can we pass references instead of cloning everything?
-    pub(crate) fn to_friend_actions(&self) -> FriendActions {
+    pub(crate) fn as_friend_actions(&self) -> FriendActions {
         FriendActions::new(
             &self.friends,
             &self.friend_cache,
@@ -555,7 +554,7 @@ impl AppData {
         )
     }
 
-    pub(crate) fn to_collab_invite_actions(&self) -> CollaborationInviteActions {
+    pub(crate) fn as_collab_invite_actions(&self) -> CollaborationInviteActions {
         CollaborationInviteActions::new(
             &self.collab_invites,
             &self.project_metadata,
@@ -564,7 +563,7 @@ impl AppData {
         )
     }
 
-    pub(crate) fn to_network_actions(&self) -> NetworkActions {
+    pub(crate) fn as_network_actions(&self) -> NetworkActions {
         NetworkActions::new(
             &self.project_metadata,
             &self.project_cache,
@@ -574,15 +573,15 @@ impl AppData {
         )
     }
 
-    pub(crate) fn to_settings_actions(&self) -> SettingsActions {
+    pub(crate) fn as_settings_actions(&self) -> SettingsActions {
         SettingsActions::new(&self.users, &self.groups)
     }
 
-    pub(crate) fn to_oauth_actions(&self) -> OAuthActions {
+    pub(crate) fn as_oauth_actions(&self) -> OAuthActions {
         OAuthActions::new(&self.oauth_clients, &self.oauth_tokens, &self.oauth_codes)
     }
 
-    pub(crate) fn to_user_actions(&self) -> UserActions {
+    pub(crate) fn as_user_actions(&self) -> UserActions {
         let data = UserActionData {
             users: &self.users,
             banned_accounts: &self.banned_accounts,
@@ -602,7 +601,7 @@ impl AppData {
         UserActions::new(data)
     }
 
-    pub(crate) fn to_host_actions(&self) -> HostActions {
+    pub(crate) fn as_host_actions(&self) -> HostActions {
         HostActions::new(&self.authorized_services)
     }
 

--- a/crates/cloud/src/collaboration_invites/actions.rs
+++ b/crates/cloud/src/collaboration_invites/actions.rs
@@ -20,21 +20,21 @@ use crate::{
     utils,
 };
 
-pub(crate) struct CollaborationInviteActions {
-    collab_invites: Collection<CollaborationInvite>,
+pub(crate) struct CollaborationInviteActions<'a> {
+    collab_invites: &'a Collection<CollaborationInvite>,
 
-    project_metadata: Collection<ProjectMetadata>,
-    project_cache: Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
-    network: Addr<TopologyActor>,
+    project_metadata: &'a Collection<ProjectMetadata>,
+    project_cache: &'a Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
+    network: &'a Addr<TopologyActor>,
 }
 
-impl CollaborationInviteActions {
+impl<'a> CollaborationInviteActions<'a> {
     pub(crate) fn new(
-        collab_invites: Collection<CollaborationInvite>,
+        collab_invites: &'a Collection<CollaborationInvite>,
 
-        project_metadata: Collection<ProjectMetadata>,
-        project_cache: Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
-        network: Addr<TopologyActor>,
+        project_metadata: &'a Collection<ProjectMetadata>,
+        project_cache: &'a Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
+        network: &'a Addr<TopologyActor>,
     ) -> Self {
         Self {
             collab_invites,

--- a/crates/cloud/src/collaboration_invites/routes.rs
+++ b/crates/cloud/src/collaboration_invites/routes.rs
@@ -16,7 +16,7 @@ async fn list_invites(
     let (receiver,) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &receiver).await?;
 
-    let actions: CollaborationInviteActions = app.to_collab_invite_actions();
+    let actions: CollaborationInviteActions = app.as_collab_invite_actions();
     let invites = actions.list_invites(&auth_vu).await?;
 
     Ok(HttpResponse::Ok().json(invites))
@@ -31,7 +31,7 @@ async fn send_invite(
     let (project_id, receiver) = path.into_inner();
     let auth_ic = auth::collaboration::try_invite(&app, &req, &project_id).await?;
 
-    let actions: CollaborationInviteActions = app.to_collab_invite_actions();
+    let actions: CollaborationInviteActions = app.as_collab_invite_actions();
     let invitation = actions.send_invite(&auth_ic, &receiver).await?;
 
     Ok(HttpResponse::Ok().json(invitation))
@@ -47,7 +47,7 @@ async fn respond_to_invite(
     let (id,) = path.into_inner();
     let auth_ri = auth::collaboration::try_respond_to_invite(&app, &req, &id).await?;
 
-    let actions: CollaborationInviteActions = app.to_collab_invite_actions();
+    let actions: CollaborationInviteActions = app.as_collab_invite_actions();
     // TODO: what should the arguments be?
     let state = actions.respond(&auth_ri, state.into_inner()).await?;
 

--- a/crates/cloud/src/collaboration_invites/routes.rs
+++ b/crates/cloud/src/collaboration_invites/routes.rs
@@ -16,7 +16,7 @@ async fn list_invites(
     let (receiver,) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &receiver).await?;
 
-    let actions: CollaborationInviteActions = app.into();
+    let actions: CollaborationInviteActions = app.to_collab_invite_actions();
     let invites = actions.list_invites(&auth_vu).await?;
 
     Ok(HttpResponse::Ok().json(invites))
@@ -31,7 +31,7 @@ async fn send_invite(
     let (project_id, receiver) = path.into_inner();
     let auth_ic = auth::collaboration::try_invite(&app, &req, &project_id).await?;
 
-    let actions: CollaborationInviteActions = app.into();
+    let actions: CollaborationInviteActions = app.to_collab_invite_actions();
     let invitation = actions.send_invite(&auth_ic, &receiver).await?;
 
     Ok(HttpResponse::Ok().json(invitation))
@@ -47,7 +47,7 @@ async fn respond_to_invite(
     let (id,) = path.into_inner();
     let auth_ri = auth::collaboration::try_respond_to_invite(&app, &req, &id).await?;
 
-    let actions: CollaborationInviteActions = app.into();
+    let actions: CollaborationInviteActions = app.to_collab_invite_actions();
     // TODO: what should the arguments be?
     let state = actions.respond(&auth_ri, state.into_inner()).await?;
 

--- a/crates/cloud/src/friends/actions.rs
+++ b/crates/cloud/src/friends/actions.rs
@@ -23,23 +23,23 @@ use crate::{
     utils,
 };
 
-pub(crate) struct FriendActions {
-    friends: Collection<FriendLink>,
-    friend_cache: Arc<RwLock<LruCache<String, Vec<String>>>>,
+pub(crate) struct FriendActions<'a> {
+    friends: &'a Collection<FriendLink>,
+    friend_cache: &'a Arc<RwLock<LruCache<String, Vec<String>>>>,
 
-    users: Collection<User>,
-    groups: Collection<Group>,
-    network: Addr<TopologyActor>,
+    users: &'a Collection<User>,
+    groups: &'a Collection<Group>,
+    network: &'a Addr<TopologyActor>,
 }
 
-impl FriendActions {
+impl<'a> FriendActions<'a> {
     pub(crate) fn new(
-        friends: Collection<FriendLink>,
-        friend_cache: Arc<RwLock<LruCache<String, Vec<String>>>>,
+        friends: &'a Collection<FriendLink>,
+        friend_cache: &'a Arc<RwLock<LruCache<String, Vec<String>>>>,
 
-        users: Collection<User>,
-        groups: Collection<Group>,
-        network: Addr<TopologyActor>,
+        users: &'a Collection<User>,
+        groups: &'a Collection<Group>,
+        network: &'a Addr<TopologyActor>,
     ) -> Self {
         Self {
             friends,
@@ -396,7 +396,7 @@ mod tests {
             .with_users(&[sender.clone(), rcvr.clone()])
             .with_friend_links(&[link])
             .run(|app_data| async move {
-                let actions: FriendActions = app_data.into();
+                let actions: FriendActions = app_data.to_friend_actions();
                 let auth_eu = auth::EditUser::test(rcvr.username.clone());
                 let link = actions
                     .respond_to_invite(&auth_eu, &sender.username, api::FriendLinkState::Approved)
@@ -422,7 +422,7 @@ mod tests {
         test_utils::setup()
             .with_users(&[rcvr.clone()])
             .run(|app_data| async move {
-                let actions: FriendActions = app_data.into();
+                let actions: FriendActions = app_data.to_friend_actions();
                 let auth_eu = auth::EditUser::test(rcvr.username.clone());
                 let result = actions
                     .respond_to_invite(&auth_eu, "sender", api::FriendLinkState::Approved)
@@ -461,7 +461,7 @@ mod tests {
             .with_users(&[sender.clone(), rcvr.clone()])
             .with_friend_links(&[link])
             .run(|app_data| async move {
-                let actions: FriendActions = app_data.into();
+                let actions: FriendActions = app_data.to_friend_actions();
                 let auth_eu = auth::EditUser::test(rcvr.username.clone());
                 let result = actions
                     .respond_to_invite(&auth_eu, "sender", api::FriendLinkState::Approved)
@@ -500,7 +500,7 @@ mod tests {
             .with_users(&[sender.clone(), rcvr.clone()])
             .with_friend_links(&[link])
             .run(|app_data| async move {
-                let actions: FriendActions = app_data.into();
+                let actions: FriendActions = app_data.to_friend_actions();
                 let auth_eu = auth::EditUser::test(rcvr.username.clone());
                 let result = actions
                     .respond_to_invite(&auth_eu, "sender", api::FriendLinkState::Approved)
@@ -539,7 +539,7 @@ mod tests {
             .with_users(&[sender.clone(), rcvr.clone()])
             .with_friend_links(&[link])
             .run(|app_data| async move {
-                let actions: FriendActions = app_data.into();
+                let actions: FriendActions = app_data.to_friend_actions();
                 let auth_eu = auth::EditUser::test(rcvr.username.clone());
                 let result = actions
                     .respond_to_invite(&auth_eu, "sender", api::FriendLinkState::Approved)
@@ -572,7 +572,7 @@ mod tests {
         test_utils::setup()
             .with_users(&[sender.clone(), rcvr.clone()])
             .run(|app_data| async move {
-                let actions: FriendActions = app_data.into();
+                let actions: FriendActions = app_data.to_friend_actions();
                 let auth_eu = auth::EditUser::test(sender.username.clone());
                 actions.send_invite(&auth_eu, &rcvr.username).await.unwrap();
 
@@ -605,7 +605,7 @@ mod tests {
         test_utils::setup()
             .with_users(&[sender.clone(), rcvr.clone()])
             .run(|app_data| async move {
-                let actions: FriendActions = app_data.into();
+                let actions: FriendActions = app_data.to_friend_actions();
                 let auth_eu = auth::EditUser::test(sender.username.clone());
                 actions.send_invite(&auth_eu, &rcvr.username).await.unwrap();
                 actions.send_invite(&auth_eu, &rcvr.username).await.unwrap();
@@ -639,7 +639,7 @@ mod tests {
         test_utils::setup()
             .with_users(&[sender.clone(), rcvr.clone()])
             .run(|app_data| async move {
-                let actions: FriendActions = app_data.into();
+                let actions: FriendActions = app_data.to_friend_actions();
 
                 // Send an invite
                 let auth_eu = auth::EditUser::test(sender.username.clone());

--- a/crates/cloud/src/friends/actions.rs
+++ b/crates/cloud/src/friends/actions.rs
@@ -396,7 +396,7 @@ mod tests {
             .with_users(&[sender.clone(), rcvr.clone()])
             .with_friend_links(&[link])
             .run(|app_data| async move {
-                let actions: FriendActions = app_data.to_friend_actions();
+                let actions: FriendActions = app_data.as_friend_actions();
                 let auth_eu = auth::EditUser::test(rcvr.username.clone());
                 let link = actions
                     .respond_to_invite(&auth_eu, &sender.username, api::FriendLinkState::Approved)
@@ -422,7 +422,7 @@ mod tests {
         test_utils::setup()
             .with_users(&[rcvr.clone()])
             .run(|app_data| async move {
-                let actions: FriendActions = app_data.to_friend_actions();
+                let actions: FriendActions = app_data.as_friend_actions();
                 let auth_eu = auth::EditUser::test(rcvr.username.clone());
                 let result = actions
                     .respond_to_invite(&auth_eu, "sender", api::FriendLinkState::Approved)
@@ -461,7 +461,7 @@ mod tests {
             .with_users(&[sender.clone(), rcvr.clone()])
             .with_friend_links(&[link])
             .run(|app_data| async move {
-                let actions: FriendActions = app_data.to_friend_actions();
+                let actions: FriendActions = app_data.as_friend_actions();
                 let auth_eu = auth::EditUser::test(rcvr.username.clone());
                 let result = actions
                     .respond_to_invite(&auth_eu, "sender", api::FriendLinkState::Approved)
@@ -500,7 +500,7 @@ mod tests {
             .with_users(&[sender.clone(), rcvr.clone()])
             .with_friend_links(&[link])
             .run(|app_data| async move {
-                let actions: FriendActions = app_data.to_friend_actions();
+                let actions: FriendActions = app_data.as_friend_actions();
                 let auth_eu = auth::EditUser::test(rcvr.username.clone());
                 let result = actions
                     .respond_to_invite(&auth_eu, "sender", api::FriendLinkState::Approved)
@@ -539,7 +539,7 @@ mod tests {
             .with_users(&[sender.clone(), rcvr.clone()])
             .with_friend_links(&[link])
             .run(|app_data| async move {
-                let actions: FriendActions = app_data.to_friend_actions();
+                let actions: FriendActions = app_data.as_friend_actions();
                 let auth_eu = auth::EditUser::test(rcvr.username.clone());
                 let result = actions
                     .respond_to_invite(&auth_eu, "sender", api::FriendLinkState::Approved)
@@ -572,7 +572,7 @@ mod tests {
         test_utils::setup()
             .with_users(&[sender.clone(), rcvr.clone()])
             .run(|app_data| async move {
-                let actions: FriendActions = app_data.to_friend_actions();
+                let actions: FriendActions = app_data.as_friend_actions();
                 let auth_eu = auth::EditUser::test(sender.username.clone());
                 actions.send_invite(&auth_eu, &rcvr.username).await.unwrap();
 
@@ -605,7 +605,7 @@ mod tests {
         test_utils::setup()
             .with_users(&[sender.clone(), rcvr.clone()])
             .run(|app_data| async move {
-                let actions: FriendActions = app_data.to_friend_actions();
+                let actions: FriendActions = app_data.as_friend_actions();
                 let auth_eu = auth::EditUser::test(sender.username.clone());
                 actions.send_invite(&auth_eu, &rcvr.username).await.unwrap();
                 actions.send_invite(&auth_eu, &rcvr.username).await.unwrap();
@@ -639,7 +639,7 @@ mod tests {
         test_utils::setup()
             .with_users(&[sender.clone(), rcvr.clone()])
             .run(|app_data| async move {
-                let actions: FriendActions = app_data.to_friend_actions();
+                let actions: FriendActions = app_data.as_friend_actions();
 
                 // Send an invite
                 let auth_eu = auth::EditUser::test(sender.username.clone());

--- a/crates/cloud/src/friends/routes.rs
+++ b/crates/cloud/src/friends/routes.rs
@@ -15,7 +15,7 @@ async fn list_friends(
     let (owner,) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &owner).await?;
 
-    let actions: FriendActions = app.into();
+    let actions: FriendActions = app.to_friend_actions();
     let friend_names = actions.list_friends(&auth_vu).await?;
 
     Ok(HttpResponse::Ok().json(friend_names))
@@ -30,7 +30,7 @@ async fn list_online_friends(
     let (owner,) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &owner).await?;
 
-    let actions: FriendActions = app.into();
+    let actions: FriendActions = app.to_friend_actions();
     let online_friends = actions.list_online_friends(&auth_vu).await?;
 
     Ok(HttpResponse::Ok().json(online_friends))
@@ -45,7 +45,7 @@ async fn unfriend(
     let (owner, friend) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &owner).await?;
 
-    let actions: FriendActions = app.into();
+    let actions: FriendActions = app.to_friend_actions();
     actions.unfriend(&auth_eu, &friend).await?;
 
     // Send "true" since it was successful but there isn't anything to send
@@ -63,7 +63,7 @@ async fn block_user(
     let (owner, friend) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &owner).await?;
 
-    let actions: FriendActions = app.into();
+    let actions: FriendActions = app.to_friend_actions();
     let link = actions.block(&auth_eu, &friend).await?;
 
     Ok(HttpResponse::Ok().json(link))
@@ -78,7 +78,7 @@ async fn unblock_user(
     let (owner, friend) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &owner).await?;
 
-    let actions: FriendActions = app.into();
+    let actions: FriendActions = app.to_friend_actions();
     actions.unblock(&auth_eu, &friend).await?;
 
     // Send "true" since it was successful but there isn't anything to send
@@ -96,7 +96,7 @@ async fn list_invites(
     let (owner,) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &owner).await?;
 
-    let actions: FriendActions = app.into();
+    let actions: FriendActions = app.to_friend_actions();
     let invites = actions.list_invites(&auth_vu).await?;
 
     Ok(HttpResponse::Ok().json(invites))
@@ -113,7 +113,7 @@ async fn send_invite(
     let recipient = recipient.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &owner).await?;
 
-    let actions: FriendActions = app.into();
+    let actions: FriendActions = app.to_friend_actions();
     let state = actions.send_invite(&auth_eu, &recipient).await?;
 
     match state {
@@ -133,7 +133,7 @@ async fn respond_to_invite(
     let state = body.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &recipient).await?;
 
-    let actions: FriendActions = app.into();
+    let actions: FriendActions = app.to_friend_actions();
     let request = actions.respond_to_invite(&auth_eu, &sender, state).await?;
 
     Ok(HttpResponse::Ok().json(request))

--- a/crates/cloud/src/friends/routes.rs
+++ b/crates/cloud/src/friends/routes.rs
@@ -15,7 +15,7 @@ async fn list_friends(
     let (owner,) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &owner).await?;
 
-    let actions: FriendActions = app.to_friend_actions();
+    let actions: FriendActions = app.as_friend_actions();
     let friend_names = actions.list_friends(&auth_vu).await?;
 
     Ok(HttpResponse::Ok().json(friend_names))
@@ -30,7 +30,7 @@ async fn list_online_friends(
     let (owner,) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &owner).await?;
 
-    let actions: FriendActions = app.to_friend_actions();
+    let actions: FriendActions = app.as_friend_actions();
     let online_friends = actions.list_online_friends(&auth_vu).await?;
 
     Ok(HttpResponse::Ok().json(online_friends))
@@ -45,7 +45,7 @@ async fn unfriend(
     let (owner, friend) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &owner).await?;
 
-    let actions: FriendActions = app.to_friend_actions();
+    let actions: FriendActions = app.as_friend_actions();
     actions.unfriend(&auth_eu, &friend).await?;
 
     // Send "true" since it was successful but there isn't anything to send
@@ -63,7 +63,7 @@ async fn block_user(
     let (owner, friend) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &owner).await?;
 
-    let actions: FriendActions = app.to_friend_actions();
+    let actions: FriendActions = app.as_friend_actions();
     let link = actions.block(&auth_eu, &friend).await?;
 
     Ok(HttpResponse::Ok().json(link))
@@ -78,7 +78,7 @@ async fn unblock_user(
     let (owner, friend) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &owner).await?;
 
-    let actions: FriendActions = app.to_friend_actions();
+    let actions: FriendActions = app.as_friend_actions();
     actions.unblock(&auth_eu, &friend).await?;
 
     // Send "true" since it was successful but there isn't anything to send
@@ -96,7 +96,7 @@ async fn list_invites(
     let (owner,) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &owner).await?;
 
-    let actions: FriendActions = app.to_friend_actions();
+    let actions: FriendActions = app.as_friend_actions();
     let invites = actions.list_invites(&auth_vu).await?;
 
     Ok(HttpResponse::Ok().json(invites))
@@ -113,7 +113,7 @@ async fn send_invite(
     let recipient = recipient.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &owner).await?;
 
-    let actions: FriendActions = app.to_friend_actions();
+    let actions: FriendActions = app.as_friend_actions();
     let state = actions.send_invite(&auth_eu, &recipient).await?;
 
     match state {
@@ -133,7 +133,7 @@ async fn respond_to_invite(
     let state = body.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &recipient).await?;
 
-    let actions: FriendActions = app.to_friend_actions();
+    let actions: FriendActions = app.as_friend_actions();
     let request = actions.respond_to_invite(&auth_eu, &sender, state).await?;
 
     Ok(HttpResponse::Ok().json(request))

--- a/crates/cloud/src/groups/actions.rs
+++ b/crates/cloud/src/groups/actions.rs
@@ -7,13 +7,13 @@ use netsblox_cloud_common::{api, Group, User};
 use crate::auth;
 use crate::errors::{InternalError, UserError};
 
-pub(crate) struct GroupActions {
-    groups: Collection<Group>,
-    users: Collection<User>,
+pub(crate) struct GroupActions<'a> {
+    groups: &'a Collection<Group>,
+    users: &'a Collection<User>,
 }
 
-impl GroupActions {
-    pub(crate) fn new(groups: Collection<Group>, users: Collection<User>) -> Self {
+impl<'a> GroupActions<'a> {
+    pub(crate) fn new(groups: &'a Collection<Group>, users: &'a Collection<User>) -> Self {
         Self { groups, users }
     }
 

--- a/crates/cloud/src/groups/routes.rs
+++ b/crates/cloud/src/groups/routes.rs
@@ -16,7 +16,7 @@ async fn list_groups(
     let (owner,) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &owner).await?;
 
-    let actions: GroupActions = app.to_group_actions();
+    let actions: GroupActions = app.as_group_actions();
     let groups = actions.list_groups(&auth_vu).await?;
 
     Ok(HttpResponse::Ok().json(groups))
@@ -31,7 +31,7 @@ async fn view_group(
     let (id,) = path.into_inner();
     let auth_vg = auth::try_view_group(&app, &req, &id).await?;
 
-    let actions: GroupActions = app.to_group_actions();
+    let actions: GroupActions = app.as_group_actions();
     let group = actions.view_group(&auth_vg).await?;
 
     Ok(HttpResponse::Ok().json(group))
@@ -47,7 +47,7 @@ async fn list_members(
 
     let auth_vg = auth::try_view_group(&app, &req, &id).await?;
 
-    let actions: GroupActions = app.to_group_actions();
+    let actions: GroupActions = app.as_group_actions();
     let members = actions.list_members(&auth_vg).await?;
 
     Ok(HttpResponse::Ok().json(members))
@@ -64,7 +64,7 @@ async fn create_group(
     let (owner,) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &owner).await?;
 
-    let actions: GroupActions = app.to_group_actions();
+    let actions: GroupActions = app.as_group_actions();
     let group = actions.create_group(&auth_eu, &body.name).await?;
 
     Ok(HttpResponse::Ok().json(group))
@@ -80,7 +80,7 @@ async fn update_group(
     let (id,) = path.into_inner();
     let auth_eg = auth::try_edit_group(&app, &req, &id).await?;
 
-    let actions: GroupActions = app.to_group_actions();
+    let actions: GroupActions = app.as_group_actions();
     let group = actions.rename_group(&auth_eg, &data.name).await?;
 
     Ok(HttpResponse::Ok().json(group))
@@ -96,7 +96,7 @@ async fn delete_group(
 
     let auth_dg = auth::try_delete_group(&app, &req, &id).await?;
 
-    let actions: GroupActions = app.to_group_actions();
+    let actions: GroupActions = app.as_group_actions();
     let group = actions.delete_group(&auth_dg).await?;
 
     Ok(HttpResponse::Ok().json(group))

--- a/crates/cloud/src/groups/routes.rs
+++ b/crates/cloud/src/groups/routes.rs
@@ -16,7 +16,7 @@ async fn list_groups(
     let (owner,) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &owner).await?;
 
-    let actions: GroupActions = app.into();
+    let actions: GroupActions = app.to_group_actions();
     let groups = actions.list_groups(&auth_vu).await?;
 
     Ok(HttpResponse::Ok().json(groups))
@@ -31,7 +31,7 @@ async fn view_group(
     let (id,) = path.into_inner();
     let auth_vg = auth::try_view_group(&app, &req, &id).await?;
 
-    let actions: GroupActions = app.into();
+    let actions: GroupActions = app.to_group_actions();
     let group = actions.view_group(&auth_vg).await?;
 
     Ok(HttpResponse::Ok().json(group))
@@ -47,7 +47,7 @@ async fn list_members(
 
     let auth_vg = auth::try_view_group(&app, &req, &id).await?;
 
-    let actions: GroupActions = app.into();
+    let actions: GroupActions = app.to_group_actions();
     let members = actions.list_members(&auth_vg).await?;
 
     Ok(HttpResponse::Ok().json(members))
@@ -64,7 +64,7 @@ async fn create_group(
     let (owner,) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &owner).await?;
 
-    let actions: GroupActions = app.into();
+    let actions: GroupActions = app.to_group_actions();
     let group = actions.create_group(&auth_eu, &body.name).await?;
 
     Ok(HttpResponse::Ok().json(group))
@@ -80,7 +80,7 @@ async fn update_group(
     let (id,) = path.into_inner();
     let auth_eg = auth::try_edit_group(&app, &req, &id).await?;
 
-    let actions: GroupActions = app.into();
+    let actions: GroupActions = app.to_group_actions();
     let group = actions.rename_group(&auth_eg, &data.name).await?;
 
     Ok(HttpResponse::Ok().json(group))
@@ -96,7 +96,7 @@ async fn delete_group(
 
     let auth_dg = auth::try_delete_group(&app, &req, &id).await?;
 
-    let actions: GroupActions = app.into();
+    let actions: GroupActions = app.to_group_actions();
     let group = actions.delete_group(&auth_dg).await?;
 
     Ok(HttpResponse::Ok().json(group))

--- a/crates/cloud/src/libraries/actions.rs
+++ b/crates/cloud/src/libraries/actions.rs
@@ -18,12 +18,12 @@ use crate::{
     utils,
 };
 
-pub(crate) struct LibraryActions {
-    libraries: Collection<Library>,
+pub(crate) struct LibraryActions<'a> {
+    libraries: &'a Collection<Library>,
 }
 
-impl LibraryActions {
-    pub(crate) fn new(libraries: Collection<Library>) -> Self {
+impl<'a> LibraryActions<'a> {
+    pub(crate) fn new(libraries: &'a Collection<Library>) -> Self {
         Self { libraries }
     }
 

--- a/crates/cloud/src/libraries/routes.rs
+++ b/crates/cloud/src/libraries/routes.rs
@@ -9,7 +9,7 @@ use actix_web::{web, HttpResponse};
 // TODO: add an endpoint for the official ones?
 #[get("/community/")]
 async fn list_community_libraries(app: web::Data<AppData>) -> Result<HttpResponse, UserError> {
-    let actions: LibraryActions = app.into();
+    let actions: LibraryActions = app.to_library_actions();
     let libraries = actions.list_community_libraries().await?;
 
     Ok(HttpResponse::Ok().json(libraries))
@@ -24,7 +24,7 @@ async fn list_user_libraries(
     let (username,) = path.into_inner();
     let auth_ll = auth::try_list_libraries(&app, &req, &username).await?;
 
-    let actions: LibraryActions = app.into();
+    let actions: LibraryActions = app.to_library_actions();
     let libraries = actions.list_user_libraries(&auth_ll).await?;
 
     Ok(HttpResponse::Ok().json(libraries))
@@ -39,7 +39,7 @@ async fn get_user_library(
     let (owner, name) = path.into_inner();
     let auth_vl = auth::try_view_library(&app, &req, &owner, &name).await?;
 
-    let actions: LibraryActions = app.into();
+    let actions: LibraryActions = app.to_library_actions();
     let blocks = actions.get_library_code(&auth_vl);
 
     Ok(HttpResponse::Ok().body(blocks))
@@ -56,7 +56,7 @@ async fn save_user_library(
 
     let auth_el = auth::try_edit_library(&app, &req, &owner).await?;
 
-    let actions: LibraryActions = app.into();
+    let actions: LibraryActions = app.to_library_actions();
     let library = actions.save_library(&auth_el, &data.into_inner()).await?;
 
     Ok(HttpResponse::Ok().json(library))
@@ -71,7 +71,7 @@ async fn delete_user_library(
     let (owner, name) = path.into_inner();
     let auth_el = auth::try_edit_library(&app, &req, &owner).await?;
 
-    let actions: LibraryActions = app.into();
+    let actions: LibraryActions = app.to_library_actions();
     let library = actions.delete_library(&auth_el, &name).await?;
 
     Ok(HttpResponse::Ok().json(library))
@@ -86,7 +86,7 @@ async fn publish_user_library(
     let (owner, name) = path.into_inner();
     let auth_pl = auth::try_publish_library(&app, &req, &owner).await?;
 
-    let actions: LibraryActions = app.into();
+    let actions: LibraryActions = app.to_library_actions();
     let library = actions.publish(&auth_pl, &name).await?;
 
     Ok(HttpResponse::Ok().json(library.state))
@@ -101,7 +101,7 @@ async fn unpublish_user_library(
     let (owner, name) = path.into_inner();
     let auth_pl = auth::try_publish_library(&app, &req, &owner).await?;
 
-    let actions: LibraryActions = app.into();
+    let actions: LibraryActions = app.to_library_actions();
     let library = actions.unpublish(&auth_pl, &name).await?;
 
     Ok(HttpResponse::Ok().json(library))
@@ -114,7 +114,7 @@ async fn list_pending_libraries(
 ) -> Result<HttpResponse, UserError> {
     let auth_lpl = auth::try_moderate_libraries(&app, &req).await?;
 
-    let actions: LibraryActions = app.into();
+    let actions: LibraryActions = app.to_library_actions();
     let libraries = actions.list_pending_libraries(&auth_lpl).await?;
 
     Ok(HttpResponse::Ok().json(libraries))
@@ -130,7 +130,7 @@ async fn set_library_state(
     let (owner, name) = path.into_inner();
     let auth_ml = auth::try_moderate_libraries(&app, &req).await?;
 
-    let actions: LibraryActions = app.into();
+    let actions: LibraryActions = app.to_library_actions();
     let library = actions
         .set_library_state(&auth_ml, &owner, &name, state.into_inner())
         .await?;

--- a/crates/cloud/src/libraries/routes.rs
+++ b/crates/cloud/src/libraries/routes.rs
@@ -9,7 +9,7 @@ use actix_web::{web, HttpResponse};
 // TODO: add an endpoint for the official ones?
 #[get("/community/")]
 async fn list_community_libraries(app: web::Data<AppData>) -> Result<HttpResponse, UserError> {
-    let actions: LibraryActions = app.to_library_actions();
+    let actions: LibraryActions = app.as_library_actions();
     let libraries = actions.list_community_libraries().await?;
 
     Ok(HttpResponse::Ok().json(libraries))
@@ -24,7 +24,7 @@ async fn list_user_libraries(
     let (username,) = path.into_inner();
     let auth_ll = auth::try_list_libraries(&app, &req, &username).await?;
 
-    let actions: LibraryActions = app.to_library_actions();
+    let actions: LibraryActions = app.as_library_actions();
     let libraries = actions.list_user_libraries(&auth_ll).await?;
 
     Ok(HttpResponse::Ok().json(libraries))
@@ -39,7 +39,7 @@ async fn get_user_library(
     let (owner, name) = path.into_inner();
     let auth_vl = auth::try_view_library(&app, &req, &owner, &name).await?;
 
-    let actions: LibraryActions = app.to_library_actions();
+    let actions: LibraryActions = app.as_library_actions();
     let blocks = actions.get_library_code(&auth_vl);
 
     Ok(HttpResponse::Ok().body(blocks))
@@ -56,7 +56,7 @@ async fn save_user_library(
 
     let auth_el = auth::try_edit_library(&app, &req, &owner).await?;
 
-    let actions: LibraryActions = app.to_library_actions();
+    let actions: LibraryActions = app.as_library_actions();
     let library = actions.save_library(&auth_el, &data.into_inner()).await?;
 
     Ok(HttpResponse::Ok().json(library))
@@ -71,7 +71,7 @@ async fn delete_user_library(
     let (owner, name) = path.into_inner();
     let auth_el = auth::try_edit_library(&app, &req, &owner).await?;
 
-    let actions: LibraryActions = app.to_library_actions();
+    let actions: LibraryActions = app.as_library_actions();
     let library = actions.delete_library(&auth_el, &name).await?;
 
     Ok(HttpResponse::Ok().json(library))
@@ -86,7 +86,7 @@ async fn publish_user_library(
     let (owner, name) = path.into_inner();
     let auth_pl = auth::try_publish_library(&app, &req, &owner).await?;
 
-    let actions: LibraryActions = app.to_library_actions();
+    let actions: LibraryActions = app.as_library_actions();
     let library = actions.publish(&auth_pl, &name).await?;
 
     Ok(HttpResponse::Ok().json(library.state))
@@ -101,7 +101,7 @@ async fn unpublish_user_library(
     let (owner, name) = path.into_inner();
     let auth_pl = auth::try_publish_library(&app, &req, &owner).await?;
 
-    let actions: LibraryActions = app.to_library_actions();
+    let actions: LibraryActions = app.as_library_actions();
     let library = actions.unpublish(&auth_pl, &name).await?;
 
     Ok(HttpResponse::Ok().json(library))
@@ -114,7 +114,7 @@ async fn list_pending_libraries(
 ) -> Result<HttpResponse, UserError> {
     let auth_lpl = auth::try_moderate_libraries(&app, &req).await?;
 
-    let actions: LibraryActions = app.to_library_actions();
+    let actions: LibraryActions = app.as_library_actions();
     let libraries = actions.list_pending_libraries(&auth_lpl).await?;
 
     Ok(HttpResponse::Ok().json(libraries))
@@ -130,7 +130,7 @@ async fn set_library_state(
     let (owner, name) = path.into_inner();
     let auth_ml = auth::try_moderate_libraries(&app, &req).await?;
 
-    let actions: LibraryActions = app.to_library_actions();
+    let actions: LibraryActions = app.as_library_actions();
     let library = actions
         .set_library_state(&auth_ml, &owner, &name, state.into_inner())
         .await?;

--- a/crates/cloud/src/network/actions.rs
+++ b/crates/cloud/src/network/actions.rs
@@ -20,22 +20,22 @@ use crate::{
 
 use super::topology::{self, TopologyActor};
 
-pub(crate) struct NetworkActions {
-    project_metadata: Collection<ProjectMetadata>,
-    occupant_invites: Collection<OccupantInvite>,
-    project_cache: Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
-    recorded_messages: Collection<SentMessage>,
-    network: Addr<TopologyActor>,
+pub(crate) struct NetworkActions<'a> {
+    project_metadata: &'a Collection<ProjectMetadata>,
+    occupant_invites: &'a Collection<OccupantInvite>,
+    project_cache: &'a Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
+    recorded_messages: &'a Collection<SentMessage>,
+    network: &'a Addr<TopologyActor>,
 }
 
-impl NetworkActions {
+impl<'a> NetworkActions<'a> {
     pub(crate) fn new(
-        project_metadata: Collection<ProjectMetadata>,
-        project_cache: Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
-        network: Addr<TopologyActor>,
+        project_metadata: &'a Collection<ProjectMetadata>,
+        project_cache: &'a Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
+        network: &'a Addr<TopologyActor>,
 
-        occupant_invites: Collection<OccupantInvite>,
-        recorded_messages: Collection<SentMessage>,
+        occupant_invites: &'a Collection<OccupantInvite>,
+        recorded_messages: &'a Collection<SentMessage>,
     ) -> Self {
         Self {
             project_metadata,

--- a/crates/cloud/src/network/routes.rs
+++ b/crates/cloud/src/network/routes.rs
@@ -126,7 +126,7 @@ async fn get_room_state(
     let (project_id,) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: NetworkActions = app.into();
+    let actions: NetworkActions = app.to_network_actions();
     let state = actions.get_room_state(&auth_vp).await?;
 
     Ok(HttpResponse::Ok().json(state))
@@ -136,7 +136,7 @@ async fn get_room_state(
 async fn get_rooms(app: web::Data<AppData>, req: HttpRequest) -> Result<HttpResponse, UserError> {
     let auth_lr = auth::try_list_rooms(&app, &req).await?;
 
-    let actions: NetworkActions = app.into();
+    let actions: NetworkActions = app.to_network_actions();
     let rooms = actions.list_rooms(&auth_lr).await?;
 
     Ok(HttpResponse::Ok().json(rooms))
@@ -149,7 +149,7 @@ async fn get_external_clients(
 ) -> Result<HttpResponse, UserError> {
     let auth_lc = auth::try_list_clients(&app, &req).await?;
 
-    let actions: NetworkActions = app.into();
+    let actions: NetworkActions = app.to_network_actions();
     let clients = actions.list_external_clients(&auth_lc).await?;
 
     Ok(HttpResponse::Ok().json(clients))
@@ -173,7 +173,7 @@ async fn invite_occupant(
     let auth_ep = auth::try_edit_project(&app, &req, None, &project_id).await?;
     let auth_link = auth::try_invite_link(&app, &req, &sender, &data.username).await?;
 
-    let actions: NetworkActions = app.into();
+    let actions: NetworkActions = app.to_network_actions();
     let invite = actions
         .invite_occupant(&auth_ep, &auth_link, &data.role_id)
         .await?;
@@ -191,7 +191,7 @@ async fn evict_occupant(
 
     let auth_eo = auth::try_evict_client(&app, &req, &client_id).await?;
 
-    let actions: NetworkActions = app.into();
+    let actions: NetworkActions = app.to_network_actions();
     let room_state = actions.evict_occupant(&auth_eo).await?;
 
     Ok(HttpResponse::Ok().json(room_state))
@@ -207,7 +207,7 @@ async fn start_network_trace(
     let (project_id,) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: NetworkActions = app.into();
+    let actions: NetworkActions = app.to_network_actions();
     let new_trace = actions.start_network_trace(&auth_vp).await?;
 
     Ok(HttpResponse::Ok().json(new_trace))
@@ -222,7 +222,7 @@ async fn stop_network_trace(
     let (project_id, trace_id) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: NetworkActions = app.into();
+    let actions: NetworkActions = app.to_network_actions();
     let trace = actions.stop_network_trace(&auth_vp, &trace_id).await?;
 
     Ok(HttpResponse::Ok().json(trace))
@@ -237,7 +237,7 @@ async fn get_network_trace_metadata(
     let (project_id, trace_id) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: NetworkActions = app.into();
+    let actions: NetworkActions = app.to_network_actions();
     let trace = actions.get_network_trace_metadata(&auth_vp, &trace_id)?;
 
     Ok(HttpResponse::Ok().json(trace))
@@ -252,7 +252,7 @@ async fn get_network_trace(
     let (project_id, trace_id) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: NetworkActions = app.into();
+    let actions: NetworkActions = app.to_network_actions();
     let messages = actions.get_network_trace(&auth_vp, &trace_id).await?;
 
     Ok(HttpResponse::Ok().json(messages))
@@ -267,7 +267,7 @@ async fn delete_network_trace(
     let (project_id, trace_id) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: NetworkActions = app.into();
+    let actions: NetworkActions = app.to_network_actions();
     let metadata = actions.delete_network_trace(&auth_vp, &trace_id).await?;
 
     Ok(HttpResponse::Ok().json(metadata))
@@ -283,7 +283,7 @@ async fn send_message(
     let message = message.into_inner();
     let auth_sm = auth::try_send_message(&app, &req, message).await?;
 
-    let actions: NetworkActions = app.into();
+    let actions: NetworkActions = app.to_network_actions();
     actions.send_message(&auth_sm);
 
     Ok(HttpResponse::Ok().finish())
@@ -298,7 +298,7 @@ async fn get_client_state(
     let (client_id,) = path.into_inner();
     let auth_vc = auth::try_view_client(&app, &req, &client_id).await?;
 
-    let actions: NetworkActions = app.into();
+    let actions: NetworkActions = app.to_network_actions();
     let client_info = actions.get_client_state(&auth_vc).await?;
 
     Ok(HttpResponse::Ok().json(client_info))

--- a/crates/cloud/src/network/routes.rs
+++ b/crates/cloud/src/network/routes.rs
@@ -126,7 +126,7 @@ async fn get_room_state(
     let (project_id,) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: NetworkActions = app.to_network_actions();
+    let actions: NetworkActions = app.as_network_actions();
     let state = actions.get_room_state(&auth_vp).await?;
 
     Ok(HttpResponse::Ok().json(state))
@@ -136,7 +136,7 @@ async fn get_room_state(
 async fn get_rooms(app: web::Data<AppData>, req: HttpRequest) -> Result<HttpResponse, UserError> {
     let auth_lr = auth::try_list_rooms(&app, &req).await?;
 
-    let actions: NetworkActions = app.to_network_actions();
+    let actions: NetworkActions = app.as_network_actions();
     let rooms = actions.list_rooms(&auth_lr).await?;
 
     Ok(HttpResponse::Ok().json(rooms))
@@ -149,7 +149,7 @@ async fn get_external_clients(
 ) -> Result<HttpResponse, UserError> {
     let auth_lc = auth::try_list_clients(&app, &req).await?;
 
-    let actions: NetworkActions = app.to_network_actions();
+    let actions: NetworkActions = app.as_network_actions();
     let clients = actions.list_external_clients(&auth_lc).await?;
 
     Ok(HttpResponse::Ok().json(clients))
@@ -173,7 +173,7 @@ async fn invite_occupant(
     let auth_ep = auth::try_edit_project(&app, &req, None, &project_id).await?;
     let auth_link = auth::try_invite_link(&app, &req, &sender, &data.username).await?;
 
-    let actions: NetworkActions = app.to_network_actions();
+    let actions: NetworkActions = app.as_network_actions();
     let invite = actions
         .invite_occupant(&auth_ep, &auth_link, &data.role_id)
         .await?;
@@ -191,7 +191,7 @@ async fn evict_occupant(
 
     let auth_eo = auth::try_evict_client(&app, &req, &client_id).await?;
 
-    let actions: NetworkActions = app.to_network_actions();
+    let actions: NetworkActions = app.as_network_actions();
     let room_state = actions.evict_occupant(&auth_eo).await?;
 
     Ok(HttpResponse::Ok().json(room_state))
@@ -207,7 +207,7 @@ async fn start_network_trace(
     let (project_id,) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: NetworkActions = app.to_network_actions();
+    let actions: NetworkActions = app.as_network_actions();
     let new_trace = actions.start_network_trace(&auth_vp).await?;
 
     Ok(HttpResponse::Ok().json(new_trace))
@@ -222,7 +222,7 @@ async fn stop_network_trace(
     let (project_id, trace_id) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: NetworkActions = app.to_network_actions();
+    let actions: NetworkActions = app.as_network_actions();
     let trace = actions.stop_network_trace(&auth_vp, &trace_id).await?;
 
     Ok(HttpResponse::Ok().json(trace))
@@ -237,7 +237,7 @@ async fn get_network_trace_metadata(
     let (project_id, trace_id) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: NetworkActions = app.to_network_actions();
+    let actions: NetworkActions = app.as_network_actions();
     let trace = actions.get_network_trace_metadata(&auth_vp, &trace_id)?;
 
     Ok(HttpResponse::Ok().json(trace))
@@ -252,7 +252,7 @@ async fn get_network_trace(
     let (project_id, trace_id) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: NetworkActions = app.to_network_actions();
+    let actions: NetworkActions = app.as_network_actions();
     let messages = actions.get_network_trace(&auth_vp, &trace_id).await?;
 
     Ok(HttpResponse::Ok().json(messages))
@@ -267,7 +267,7 @@ async fn delete_network_trace(
     let (project_id, trace_id) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: NetworkActions = app.to_network_actions();
+    let actions: NetworkActions = app.as_network_actions();
     let metadata = actions.delete_network_trace(&auth_vp, &trace_id).await?;
 
     Ok(HttpResponse::Ok().json(metadata))
@@ -283,7 +283,7 @@ async fn send_message(
     let message = message.into_inner();
     let auth_sm = auth::try_send_message(&app, &req, message).await?;
 
-    let actions: NetworkActions = app.to_network_actions();
+    let actions: NetworkActions = app.as_network_actions();
     actions.send_message(&auth_sm);
 
     Ok(HttpResponse::Ok().finish())
@@ -298,7 +298,7 @@ async fn get_client_state(
     let (client_id,) = path.into_inner();
     let auth_vc = auth::try_view_client(&app, &req, &client_id).await?;
 
-    let actions: NetworkActions = app.to_network_actions();
+    let actions: NetworkActions = app.as_network_actions();
     let client_info = actions.get_client_state(&auth_vc).await?;
 
     Ok(HttpResponse::Ok().json(client_info))

--- a/crates/cloud/src/oauth/actions.rs
+++ b/crates/cloud/src/oauth/actions.rs
@@ -17,17 +17,17 @@ use super::{
     routes::{AuthorizeClientParams, Scope},
 };
 
-pub(crate) struct OAuthActions {
-    clients: Collection<OAuthClient>,
-    tokens: Collection<OAuthToken>,
-    codes: Collection<oauth::Code>,
+pub(crate) struct OAuthActions<'a> {
+    clients: &'a Collection<OAuthClient>,
+    tokens: &'a Collection<OAuthToken>,
+    codes: &'a Collection<oauth::Code>,
 }
 
-impl OAuthActions {
+impl<'a> OAuthActions<'a> {
     pub(crate) fn new(
-        clients: Collection<OAuthClient>,
-        tokens: Collection<OAuthToken>,
-        codes: Collection<oauth::Code>,
+        clients: &'a Collection<OAuthClient>,
+        tokens: &'a Collection<OAuthToken>,
+        codes: &'a Collection<oauth::Code>,
     ) -> Self {
         Self {
             clients,

--- a/crates/cloud/src/oauth/routes.rs
+++ b/crates/cloud/src/oauth/routes.rs
@@ -42,7 +42,7 @@ async fn authorization_page(
     };
 
     let response = if let Ok(auth_eu) = auth_eu {
-        let actions: OAuthActions = app.to_oauth_actions();
+        let actions: OAuthActions = app.as_oauth_actions();
         let html = actions
             .render_auth_page(&auth_eu, &params.client_id)
             .await?;
@@ -85,7 +85,7 @@ async fn authorize_client(
     let (username,) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &username).await?;
 
-    let actions: OAuthActions = app.to_oauth_actions();
+    let actions: OAuthActions = app.as_oauth_actions();
     let url = actions.authorize(&auth_eu, &params.into_inner()).await?;
     let response = HttpResponse::Found()
         .insert_header(("Location", url.as_str()))
@@ -178,7 +178,7 @@ async fn create_client(
 ) -> Result<HttpResponse, UserError> {
     let auth_cc = auth::try_manage_client(&app, &req).await?;
 
-    let actions: OAuthActions = app.to_oauth_actions();
+    let actions: OAuthActions = app.as_oauth_actions();
     let client = actions.create_client(&auth_cc, &params.name).await?;
     Ok(HttpResponse::Ok().json(client))
 }
@@ -190,7 +190,7 @@ async fn list_clients(
 ) -> Result<HttpResponse, UserError> {
     let auth_cc = auth::try_manage_client(&app, &req).await?;
 
-    let actions: OAuthActions = app.to_oauth_actions();
+    let actions: OAuthActions = app.as_oauth_actions();
     let clients = actions.list_clients(&auth_cc).await?;
 
     Ok(HttpResponse::Ok().json(clients))
@@ -205,7 +205,7 @@ async fn remove_client(
     let auth_cc = auth::try_manage_client(&app, &req).await?;
     let (client_id,) = path.into_inner();
 
-    let actions: OAuthActions = app.to_oauth_actions();
+    let actions: OAuthActions = app.as_oauth_actions();
     let client = actions.delete_client(&auth_cc, &client_id).await?;
 
     Ok(HttpResponse::Ok().json(client))

--- a/crates/cloud/src/oauth/routes.rs
+++ b/crates/cloud/src/oauth/routes.rs
@@ -42,7 +42,7 @@ async fn authorization_page(
     };
 
     let response = if let Ok(auth_eu) = auth_eu {
-        let actions: OAuthActions = app.into();
+        let actions: OAuthActions = app.to_oauth_actions();
         let html = actions
             .render_auth_page(&auth_eu, &params.client_id)
             .await?;
@@ -85,7 +85,7 @@ async fn authorize_client(
     let (username,) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &username).await?;
 
-    let actions: OAuthActions = app.into();
+    let actions: OAuthActions = app.to_oauth_actions();
     let url = actions.authorize(&auth_eu, &params.into_inner()).await?;
     let response = HttpResponse::Found()
         .insert_header(("Location", url.as_str()))
@@ -178,7 +178,7 @@ async fn create_client(
 ) -> Result<HttpResponse, UserError> {
     let auth_cc = auth::try_manage_client(&app, &req).await?;
 
-    let actions: OAuthActions = app.into();
+    let actions: OAuthActions = app.to_oauth_actions();
     let client = actions.create_client(&auth_cc, &params.name).await?;
     Ok(HttpResponse::Ok().json(client))
 }
@@ -190,7 +190,7 @@ async fn list_clients(
 ) -> Result<HttpResponse, UserError> {
     let auth_cc = auth::try_manage_client(&app, &req).await?;
 
-    let actions: OAuthActions = app.into();
+    let actions: OAuthActions = app.to_oauth_actions();
     let clients = actions.list_clients(&auth_cc).await?;
 
     Ok(HttpResponse::Ok().json(clients))
@@ -205,7 +205,7 @@ async fn remove_client(
     let auth_cc = auth::try_manage_client(&app, &req).await?;
     let (client_id,) = path.into_inner();
 
-    let actions: OAuthActions = app.into();
+    let actions: OAuthActions = app.to_oauth_actions();
     let client = actions.delete_client(&auth_cc, &client_id).await?;
 
     Ok(HttpResponse::Ok().json(client))

--- a/crates/cloud/src/projects/actions.rs
+++ b/crates/cloud/src/projects/actions.rs
@@ -31,24 +31,23 @@ use netsblox_cloud_common::{Project, RoleMetadata};
 use s3::operation::put_object::PutObjectOutput;
 use uuid::Uuid;
 
-// FIXME: pass this as an argument to ProjectActions
-pub(crate) struct ProjectActions {
-    project_metadata: Collection<ProjectMetadata>,
-    project_cache: Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
-    network: Addr<TopologyActor>,
+pub(crate) struct ProjectActions<'a> {
+    project_metadata: &'a Collection<ProjectMetadata>,
+    project_cache: &'a Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
+    network: &'a Addr<TopologyActor>,
 
-    bucket: String,
-    s3: s3::Client,
+    bucket: &'a String,
+    s3: &'a s3::Client,
 }
 
-impl ProjectActions {
+impl<'a> ProjectActions<'a> {
     pub(crate) fn new(
-        project_metadata: Collection<ProjectMetadata>,
-        project_cache: Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
-        network: Addr<TopologyActor>,
+        project_metadata: &'a Collection<ProjectMetadata>,
+        project_cache: &'a Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
+        network: &'a Addr<TopologyActor>,
 
-        bucket: String,
-        s3: s3::Client,
+        bucket: &'a String,
+        s3: &'a s3::Client,
     ) -> Self {
         Self {
             project_metadata,

--- a/crates/cloud/src/projects/routes.rs
+++ b/crates/cloud/src/projects/routes.rs
@@ -29,7 +29,7 @@ async fn create_project(
         .ok_or(UserError::LoginRequiredError)?;
 
     let auth_eu = auth::try_edit_user(&app, &req, client_id.as_ref(), &owner).await?;
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let metadata = actions.create_project(&auth_eu, project_data).await?;
 
     Ok(HttpResponse::Ok().json(metadata))
@@ -44,7 +44,7 @@ async fn list_user_projects(
     let (username,) = path.into_inner();
     let auth_lp = auth::try_list_projects(&app, &req, &username).await?;
 
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let projects = actions.list_projects(&auth_lp).await?;
 
     Ok(HttpResponse::Ok().json(projects))
@@ -59,7 +59,7 @@ async fn list_shared_projects(
     let (username,) = path.into_inner();
     let auth_lp = auth::try_list_projects(&app, &req, &username).await?;
 
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let projects = actions.list_shared_projects(&auth_lp).await?;
 
     Ok(HttpResponse::Ok().json(projects))
@@ -81,7 +81,7 @@ async fn get_project_named(
         .ok_or(UserError::ProjectNotFoundError)?;
 
     let auth_vp = auth::try_view_project(&app, &req, None, &metadata.id).await?;
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
 
     let project = actions.get_project(&auth_vp).await?;
     Ok(HttpResponse::Ok().json(project))
@@ -104,7 +104,7 @@ async fn get_project_metadata(
 
     let auth_vp = auth::try_view_project(&app, &req, None, &metadata.id).await?;
 
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let metadata = actions.get_project_metadata(&auth_vp);
 
     Ok(HttpResponse::Ok().json(metadata))
@@ -119,7 +119,7 @@ async fn get_project_id_metadata(
     let (project_id,) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let metadata = actions.get_project_metadata(&auth_vp);
 
     Ok(HttpResponse::Ok().json(metadata))
@@ -134,7 +134,7 @@ async fn get_project(
     let (project_id,) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let project = actions.get_project(&auth_vp).await?;
 
     Ok(HttpResponse::Ok().json(project))
@@ -148,7 +148,7 @@ async fn publish_project(
 ) -> Result<HttpResponse, UserError> {
     let (project_id,) = path.into_inner();
     let auth_ep = auth::try_edit_project(&app, &req, None, &project_id).await?;
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let state = actions.publish_project(&auth_ep).await?;
     Ok(HttpResponse::Ok().json(state))
 }
@@ -161,7 +161,7 @@ async fn unpublish_project(
 ) -> Result<HttpResponse, UserError> {
     let (project_id,) = path.into_inner();
     let auth_ep = auth::try_edit_project(&app, &req, None, &project_id).await?;
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let state = actions.unpublish_project(&auth_ep).await?;
     Ok(HttpResponse::Ok().json(state))
 }
@@ -174,7 +174,7 @@ async fn delete_project(
 ) -> Result<HttpResponse, UserError> {
     let (project_id,) = path.into_inner();
     let auth_dp = auth::try_delete_project(&app, &req, None, &project_id).await?;
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let project = actions.delete_project(&auth_dp).await?;
 
     Ok(HttpResponse::Ok().json(project))
@@ -192,7 +192,7 @@ async fn update_project(
     let body = body.into_inner();
     let auth_ep = auth::try_edit_project(&app, &req, body.client_id, &project_id).await?;
 
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let metadata = actions.rename_project(&auth_ep, &body.name).await?;
     Ok(HttpResponse::Ok().json(metadata))
 }
@@ -215,7 +215,7 @@ async fn get_latest_project(
     let params = params.into_inner();
     let auth_vp =
         auth::try_view_project(&app, &req, params.client_id.as_ref(), &project_id).await?;
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let project = actions.get_latest_project(&auth_vp).await?;
     Ok(HttpResponse::Ok().json(project))
 }
@@ -236,7 +236,7 @@ async fn get_project_thumbnail(
     let (project_id,) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let thumbnail = actions
         .get_project_thumbnail(&auth_vp, params.aspect_ratio)
         .await?;
@@ -271,7 +271,7 @@ async fn create_role(
     let (project_id,) = path.into_inner();
     let auth_ep = auth::try_edit_project(&app, &req, None, &project_id).await?;
 
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let updated_metadata = actions
         .create_role(&auth_ep, body.into_inner().into())
         .await?;
@@ -288,7 +288,7 @@ async fn get_role(
     let (project_id, role_id) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let role = actions.get_role(&auth_vp, role_id).await?;
 
     Ok(HttpResponse::Ok().json(role))
@@ -304,7 +304,7 @@ async fn delete_role(
 
     let auth_ep = auth::try_edit_project(&app, &req, None, &project_id).await?;
 
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let metadata = actions.delete_role(&auth_ep, role_id).await?;
 
     Ok(HttpResponse::Ok().json(metadata))
@@ -319,7 +319,7 @@ async fn save_role(
 ) -> Result<HttpResponse, UserError> {
     let (project_id, role_id) = path.into_inner();
     let auth_ep = auth::try_edit_project(&app, &req, None, &project_id).await?;
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let metadata = actions
         .save_role(&auth_ep, &role_id, body.into_inner())
         .await?;
@@ -338,7 +338,7 @@ async fn rename_role(
     let body = body.into_inner();
     let auth_ep = auth::try_edit_project(&app, &req, body.client_id, &project_id).await?;
 
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let metadata = actions.rename_role(&auth_ep, role_id, &body.name).await?;
     Ok(HttpResponse::Ok().json(metadata))
 }
@@ -355,7 +355,7 @@ async fn get_latest_role(
     let auth_vp =
         auth::try_view_project(&app, &req, params.client_id.as_ref(), &project_id).await?;
 
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let (_, role_data) = actions.fetch_role_data(&auth_vp, role_id).await?;
 
     Ok(HttpResponse::Ok().json(role_data))
@@ -378,7 +378,7 @@ async fn report_latest_role(
     let (project_id, role_id) = path.into_inner();
     let client_id = params.into_inner().client_id;
     let auth_ep = auth::try_edit_project(&app, &req, client_id, &project_id).await?;
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let resp = body.into_inner();
     actions
         .set_latest_role(&auth_ep, &role_id, &resp.id, resp.data)
@@ -396,7 +396,7 @@ async fn list_collaborators(
     let (project_id,) = path.into_inner();
     let metadata = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let collaborators = actions.get_collaborators(&metadata);
 
     Ok(HttpResponse::Ok().json(collaborators))
@@ -410,7 +410,7 @@ async fn remove_collaborator(
 ) -> Result<HttpResponse, UserError> {
     let (project_id, username) = path.into_inner();
     let edit_proj = auth::try_edit_project(&app, &req, None, &project_id).await?;
-    let actions: ProjectActions = app.to_project_actions();
+    let actions: ProjectActions = app.as_project_actions();
     let metadata = actions.remove_collaborator(&edit_proj, &username).await?;
 
     Ok(HttpResponse::Ok().json(metadata))

--- a/crates/cloud/src/projects/routes.rs
+++ b/crates/cloud/src/projects/routes.rs
@@ -29,7 +29,7 @@ async fn create_project(
         .ok_or(UserError::LoginRequiredError)?;
 
     let auth_eu = auth::try_edit_user(&app, &req, client_id.as_ref(), &owner).await?;
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let metadata = actions.create_project(&auth_eu, project_data).await?;
 
     Ok(HttpResponse::Ok().json(metadata))
@@ -44,7 +44,7 @@ async fn list_user_projects(
     let (username,) = path.into_inner();
     let auth_lp = auth::try_list_projects(&app, &req, &username).await?;
 
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let projects = actions.list_projects(&auth_lp).await?;
 
     Ok(HttpResponse::Ok().json(projects))
@@ -59,7 +59,7 @@ async fn list_shared_projects(
     let (username,) = path.into_inner();
     let auth_lp = auth::try_list_projects(&app, &req, &username).await?;
 
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let projects = actions.list_shared_projects(&auth_lp).await?;
 
     Ok(HttpResponse::Ok().json(projects))
@@ -81,7 +81,7 @@ async fn get_project_named(
         .ok_or(UserError::ProjectNotFoundError)?;
 
     let auth_vp = auth::try_view_project(&app, &req, None, &metadata.id).await?;
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
 
     let project = actions.get_project(&auth_vp).await?;
     Ok(HttpResponse::Ok().json(project))
@@ -104,7 +104,7 @@ async fn get_project_metadata(
 
     let auth_vp = auth::try_view_project(&app, &req, None, &metadata.id).await?;
 
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let metadata = actions.get_project_metadata(&auth_vp);
 
     Ok(HttpResponse::Ok().json(metadata))
@@ -119,7 +119,7 @@ async fn get_project_id_metadata(
     let (project_id,) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let metadata = actions.get_project_metadata(&auth_vp);
 
     Ok(HttpResponse::Ok().json(metadata))
@@ -134,7 +134,7 @@ async fn get_project(
     let (project_id,) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let project = actions.get_project(&auth_vp).await?;
 
     Ok(HttpResponse::Ok().json(project))
@@ -148,7 +148,7 @@ async fn publish_project(
 ) -> Result<HttpResponse, UserError> {
     let (project_id,) = path.into_inner();
     let auth_ep = auth::try_edit_project(&app, &req, None, &project_id).await?;
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let state = actions.publish_project(&auth_ep).await?;
     Ok(HttpResponse::Ok().json(state))
 }
@@ -161,7 +161,7 @@ async fn unpublish_project(
 ) -> Result<HttpResponse, UserError> {
     let (project_id,) = path.into_inner();
     let auth_ep = auth::try_edit_project(&app, &req, None, &project_id).await?;
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let state = actions.unpublish_project(&auth_ep).await?;
     Ok(HttpResponse::Ok().json(state))
 }
@@ -174,7 +174,7 @@ async fn delete_project(
 ) -> Result<HttpResponse, UserError> {
     let (project_id,) = path.into_inner();
     let auth_dp = auth::try_delete_project(&app, &req, None, &project_id).await?;
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let project = actions.delete_project(&auth_dp).await?;
 
     Ok(HttpResponse::Ok().json(project))
@@ -192,7 +192,7 @@ async fn update_project(
     let body = body.into_inner();
     let auth_ep = auth::try_edit_project(&app, &req, body.client_id, &project_id).await?;
 
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let metadata = actions.rename_project(&auth_ep, &body.name).await?;
     Ok(HttpResponse::Ok().json(metadata))
 }
@@ -215,7 +215,7 @@ async fn get_latest_project(
     let params = params.into_inner();
     let auth_vp =
         auth::try_view_project(&app, &req, params.client_id.as_ref(), &project_id).await?;
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let project = actions.get_latest_project(&auth_vp).await?;
     Ok(HttpResponse::Ok().json(project))
 }
@@ -236,7 +236,7 @@ async fn get_project_thumbnail(
     let (project_id,) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let thumbnail = actions
         .get_project_thumbnail(&auth_vp, params.aspect_ratio)
         .await?;
@@ -271,7 +271,7 @@ async fn create_role(
     let (project_id,) = path.into_inner();
     let auth_ep = auth::try_edit_project(&app, &req, None, &project_id).await?;
 
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let updated_metadata = actions
         .create_role(&auth_ep, body.into_inner().into())
         .await?;
@@ -288,7 +288,7 @@ async fn get_role(
     let (project_id, role_id) = path.into_inner();
     let auth_vp = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let role = actions.get_role(&auth_vp, role_id).await?;
 
     Ok(HttpResponse::Ok().json(role))
@@ -304,7 +304,7 @@ async fn delete_role(
 
     let auth_ep = auth::try_edit_project(&app, &req, None, &project_id).await?;
 
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let metadata = actions.delete_role(&auth_ep, role_id).await?;
 
     Ok(HttpResponse::Ok().json(metadata))
@@ -319,7 +319,7 @@ async fn save_role(
 ) -> Result<HttpResponse, UserError> {
     let (project_id, role_id) = path.into_inner();
     let auth_ep = auth::try_edit_project(&app, &req, None, &project_id).await?;
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let metadata = actions
         .save_role(&auth_ep, &role_id, body.into_inner())
         .await?;
@@ -338,7 +338,7 @@ async fn rename_role(
     let body = body.into_inner();
     let auth_ep = auth::try_edit_project(&app, &req, body.client_id, &project_id).await?;
 
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let metadata = actions.rename_role(&auth_ep, role_id, &body.name).await?;
     Ok(HttpResponse::Ok().json(metadata))
 }
@@ -355,7 +355,7 @@ async fn get_latest_role(
     let auth_vp =
         auth::try_view_project(&app, &req, params.client_id.as_ref(), &project_id).await?;
 
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let (_, role_data) = actions.fetch_role_data(&auth_vp, role_id).await?;
 
     Ok(HttpResponse::Ok().json(role_data))
@@ -378,7 +378,7 @@ async fn report_latest_role(
     let (project_id, role_id) = path.into_inner();
     let client_id = params.into_inner().client_id;
     let auth_ep = auth::try_edit_project(&app, &req, client_id, &project_id).await?;
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let resp = body.into_inner();
     actions
         .set_latest_role(&auth_ep, &role_id, &resp.id, resp.data)
@@ -396,7 +396,7 @@ async fn list_collaborators(
     let (project_id,) = path.into_inner();
     let metadata = auth::try_view_project(&app, &req, None, &project_id).await?;
 
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let collaborators = actions.get_collaborators(&metadata);
 
     Ok(HttpResponse::Ok().json(collaborators))
@@ -410,7 +410,7 @@ async fn remove_collaborator(
 ) -> Result<HttpResponse, UserError> {
     let (project_id, username) = path.into_inner();
     let edit_proj = auth::try_edit_project(&app, &req, None, &project_id).await?;
-    let actions: ProjectActions = app.into();
+    let actions: ProjectActions = app.to_project_actions();
     let metadata = actions.remove_collaborator(&edit_proj, &username).await?;
 
     Ok(HttpResponse::Ok().json(metadata))

--- a/crates/cloud/src/services/hosts/actions.rs
+++ b/crates/cloud/src/services/hosts/actions.rs
@@ -9,12 +9,12 @@ use crate::{
     errors::{InternalError, UserError},
 };
 
-pub(crate) struct HostActions {
-    authorized_services: Collection<AuthorizedServiceHost>,
+pub(crate) struct HostActions<'a> {
+    authorized_services: &'a Collection<AuthorizedServiceHost>,
 }
 
-impl HostActions {
-    pub(crate) fn new(authorized_services: Collection<AuthorizedServiceHost>) -> Self {
+impl<'a> HostActions<'a> {
+    pub(crate) fn new(authorized_services: &'a Collection<AuthorizedServiceHost>) -> Self {
         Self {
             authorized_services,
         }

--- a/crates/cloud/src/services/hosts/routes.rs
+++ b/crates/cloud/src/services/hosts/routes.rs
@@ -20,7 +20,7 @@ async fn list_group_hosts(
     let (id,) = path.into_inner();
     let auth_vg = auth::try_view_group(&app, &req, &id).await?;
 
-    let actions: GroupActions = app.to_group_actions();
+    let actions: GroupActions = app.as_group_actions();
     let group = actions.view_group(&auth_vg).await?;
 
     Ok(HttpResponse::Ok().json(group.services_hosts.unwrap_or_default()))
@@ -37,7 +37,7 @@ async fn set_group_hosts(
 
     let auth_eg = auth::try_edit_group(&app, &req, &id).await?;
 
-    let actions: GroupActions = app.to_group_actions();
+    let actions: GroupActions = app.as_group_actions();
     let group = actions.set_group_hosts(&auth_eg, &hosts).await?;
 
     Ok(HttpResponse::Ok().json(group))
@@ -52,7 +52,7 @@ async fn list_user_hosts(
     let (username,) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     let user = actions.get_user(&auth_vu).await?;
 
     Ok(HttpResponse::Ok().json(user.services_hosts.unwrap_or_default()))
@@ -68,7 +68,7 @@ async fn set_user_hosts(
     let (username,) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     let user = actions.set_hosts(&auth_eu, &hosts).await?;
 
     Ok(HttpResponse::Ok().json(user))
@@ -131,7 +131,7 @@ async fn get_authorized_hosts(
 ) -> Result<HttpResponse, UserError> {
     let auth_vah = auth::try_view_auth_hosts(&app, &req).await?;
 
-    let actions: HostActions = app.to_host_actions();
+    let actions: HostActions = app.as_host_actions();
     let hosts = actions.get_hosts(&auth_vah).await?;
 
     Ok(HttpResponse::Ok().json(hosts))
@@ -145,7 +145,7 @@ async fn authorize_host(
 ) -> Result<HttpResponse, UserError> {
     let auth_ah = auth::try_auth_host(&app, &req).await?;
 
-    let actions: HostActions = app.to_host_actions();
+    let actions: HostActions = app.as_host_actions();
     let secret = actions.authorize(&auth_ah, host_data.into_inner()).await?;
 
     Ok(HttpResponse::Ok().json(secret))
@@ -160,7 +160,7 @@ async fn unauthorize_host(
     let (host_id,) = path.into_inner();
     let auth_ah = auth::try_auth_host(&app, &req).await?;
 
-    let actions: HostActions = app.to_host_actions();
+    let actions: HostActions = app.as_host_actions();
     let host = actions.unauthorize(&auth_ah, &host_id).await?;
 
     Ok(HttpResponse::Ok().json(host))

--- a/crates/cloud/src/services/hosts/routes.rs
+++ b/crates/cloud/src/services/hosts/routes.rs
@@ -20,7 +20,7 @@ async fn list_group_hosts(
     let (id,) = path.into_inner();
     let auth_vg = auth::try_view_group(&app, &req, &id).await?;
 
-    let actions: GroupActions = app.into();
+    let actions: GroupActions = app.to_group_actions();
     let group = actions.view_group(&auth_vg).await?;
 
     Ok(HttpResponse::Ok().json(group.services_hosts.unwrap_or_default()))
@@ -37,7 +37,7 @@ async fn set_group_hosts(
 
     let auth_eg = auth::try_edit_group(&app, &req, &id).await?;
 
-    let actions: GroupActions = app.into();
+    let actions: GroupActions = app.to_group_actions();
     let group = actions.set_group_hosts(&auth_eg, &hosts).await?;
 
     Ok(HttpResponse::Ok().json(group))
@@ -52,7 +52,7 @@ async fn list_user_hosts(
     let (username,) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     let user = actions.get_user(&auth_vu).await?;
 
     Ok(HttpResponse::Ok().json(user.services_hosts.unwrap_or_default()))
@@ -68,7 +68,7 @@ async fn set_user_hosts(
     let (username,) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     let user = actions.set_hosts(&auth_eu, &hosts).await?;
 
     Ok(HttpResponse::Ok().json(user))
@@ -131,7 +131,7 @@ async fn get_authorized_hosts(
 ) -> Result<HttpResponse, UserError> {
     let auth_vah = auth::try_view_auth_hosts(&app, &req).await?;
 
-    let actions: HostActions = app.into();
+    let actions: HostActions = app.to_host_actions();
     let hosts = actions.get_hosts(&auth_vah).await?;
 
     Ok(HttpResponse::Ok().json(hosts))
@@ -145,7 +145,7 @@ async fn authorize_host(
 ) -> Result<HttpResponse, UserError> {
     let auth_ah = auth::try_auth_host(&app, &req).await?;
 
-    let actions: HostActions = app.into();
+    let actions: HostActions = app.to_host_actions();
     let secret = actions.authorize(&auth_ah, host_data.into_inner()).await?;
 
     Ok(HttpResponse::Ok().json(secret))
@@ -160,7 +160,7 @@ async fn unauthorize_host(
     let (host_id,) = path.into_inner();
     let auth_ah = auth::try_auth_host(&app, &req).await?;
 
-    let actions: HostActions = app.into();
+    let actions: HostActions = app.to_host_actions();
     let host = actions.unauthorize(&auth_ah, &host_id).await?;
 
     Ok(HttpResponse::Ok().json(host))

--- a/crates/cloud/src/services/settings/actions.rs
+++ b/crates/cloud/src/services/settings/actions.rs
@@ -9,13 +9,13 @@ use crate::{
     errors::{InternalError, UserError},
 };
 
-pub(crate) struct SettingsActions {
-    users: Collection<User>,
-    groups: Collection<Group>,
+pub(crate) struct SettingsActions<'a> {
+    users: &'a Collection<User>,
+    groups: &'a Collection<Group>,
 }
 
-impl SettingsActions {
-    pub(crate) fn new(users: Collection<User>, groups: Collection<Group>) -> Self {
+impl<'a> SettingsActions<'a> {
+    pub(crate) fn new(users: &'a Collection<User>, groups: &'a Collection<Group>) -> Self {
         Self { users, groups }
     }
     pub(crate) async fn get_settings(

--- a/crates/cloud/src/services/settings/routes.rs
+++ b/crates/cloud/src/services/settings/routes.rs
@@ -16,7 +16,7 @@ async fn list_user_hosts_with_settings(
     let (username,) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     let settings = actions.get_service_settings(&auth_vu).await?;
     let hosts: Vec<_> = settings.keys().collect();
 
@@ -32,7 +32,7 @@ async fn get_user_settings(
     let (username, host) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     let settings = actions.get_service_settings(&auth_vu).await?;
     let empty_string = String::default();
     let settings = settings.get(&host).unwrap_or(&empty_string).to_owned();
@@ -49,7 +49,7 @@ async fn get_all_settings(
     let (username, host) = path.into_inner();
 
     let auth_vu = auth::try_view_user(&app, &req, None, &username).await?;
-    let actions: SettingsActions = app.to_settings_actions();
+    let actions: SettingsActions = app.as_settings_actions();
     let all_settings = actions.get_settings(&auth_vu, &host).await?;
 
     Ok(HttpResponse::Ok().json(all_settings))
@@ -67,7 +67,7 @@ async fn set_user_settings(
 
     let settings = std::str::from_utf8(&body).map_err(|_err| UserError::InternalError)?;
 
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     actions.set_user_settings(&auth_eu, &host, settings).await?;
 
     Ok(HttpResponse::Ok().finish())
@@ -82,7 +82,7 @@ async fn delete_user_settings(
     let (username, host) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     actions.delete_user_settings(&auth_eu, &host).await?;
 
     Ok(HttpResponse::Ok().finish())
@@ -98,7 +98,7 @@ async fn list_group_hosts_with_settings(
 
     let auth_vg = auth::try_view_group(&app, &req, &group_id).await?;
 
-    let actions: GroupActions = app.to_group_actions();
+    let actions: GroupActions = app.as_group_actions();
     let settings = actions.get_service_settings(&auth_vg).await?;
     let hosts: Vec<_> = settings.keys().collect();
 
@@ -114,7 +114,7 @@ async fn get_group_settings(
     let (group_id, host) = path.into_inner();
     let auth_vg = auth::try_view_group(&app, &req, &group_id).await?;
 
-    let actions: GroupActions = app.to_group_actions();
+    let actions: GroupActions = app.as_group_actions();
     let settings = actions.get_service_settings(&auth_vg).await?;
 
     let empty_string = String::default();
@@ -135,7 +135,7 @@ async fn set_group_settings(
 
     let auth_eg = auth::try_edit_group(&app, &req, &group_id).await?;
 
-    let actions: GroupActions = app.to_group_actions();
+    let actions: GroupActions = app.as_group_actions();
     actions
         .set_service_settings(&auth_eg, &host, &settings)
         .await?;
@@ -153,7 +153,7 @@ async fn delete_group_settings(
 
     let auth_eg = auth::try_edit_group(&app, &req, &group_id).await?;
 
-    let actions: GroupActions = app.to_group_actions();
+    let actions: GroupActions = app.as_group_actions();
     actions.delete_service_settings(&auth_eg, &host).await?;
 
     Ok(HttpResponse::Ok().finish())

--- a/crates/cloud/src/services/settings/routes.rs
+++ b/crates/cloud/src/services/settings/routes.rs
@@ -16,7 +16,7 @@ async fn list_user_hosts_with_settings(
     let (username,) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     let settings = actions.get_service_settings(&auth_vu).await?;
     let hosts: Vec<_> = settings.keys().collect();
 
@@ -32,7 +32,7 @@ async fn get_user_settings(
     let (username, host) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     let settings = actions.get_service_settings(&auth_vu).await?;
     let empty_string = String::default();
     let settings = settings.get(&host).unwrap_or(&empty_string).to_owned();
@@ -49,7 +49,7 @@ async fn get_all_settings(
     let (username, host) = path.into_inner();
 
     let auth_vu = auth::try_view_user(&app, &req, None, &username).await?;
-    let actions: SettingsActions = app.into();
+    let actions: SettingsActions = app.to_settings_actions();
     let all_settings = actions.get_settings(&auth_vu, &host).await?;
 
     Ok(HttpResponse::Ok().json(all_settings))
@@ -67,7 +67,7 @@ async fn set_user_settings(
 
     let settings = std::str::from_utf8(&body).map_err(|_err| UserError::InternalError)?;
 
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     actions.set_user_settings(&auth_eu, &host, settings).await?;
 
     Ok(HttpResponse::Ok().finish())
@@ -82,7 +82,7 @@ async fn delete_user_settings(
     let (username, host) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     actions.delete_user_settings(&auth_eu, &host).await?;
 
     Ok(HttpResponse::Ok().finish())
@@ -98,7 +98,7 @@ async fn list_group_hosts_with_settings(
 
     let auth_vg = auth::try_view_group(&app, &req, &group_id).await?;
 
-    let actions: GroupActions = app.into();
+    let actions: GroupActions = app.to_group_actions();
     let settings = actions.get_service_settings(&auth_vg).await?;
     let hosts: Vec<_> = settings.keys().collect();
 
@@ -114,7 +114,7 @@ async fn get_group_settings(
     let (group_id, host) = path.into_inner();
     let auth_vg = auth::try_view_group(&app, &req, &group_id).await?;
 
-    let actions: GroupActions = app.into();
+    let actions: GroupActions = app.to_group_actions();
     let settings = actions.get_service_settings(&auth_vg).await?;
 
     let empty_string = String::default();
@@ -135,7 +135,7 @@ async fn set_group_settings(
 
     let auth_eg = auth::try_edit_group(&app, &req, &group_id).await?;
 
-    let actions: GroupActions = app.into();
+    let actions: GroupActions = app.to_group_actions();
     actions
         .set_service_settings(&auth_eg, &host, &settings)
         .await?;
@@ -153,7 +153,7 @@ async fn delete_group_settings(
 
     let auth_eg = auth::try_edit_group(&app, &req, &group_id).await?;
 
-    let actions: GroupActions = app.into();
+    let actions: GroupActions = app.to_group_actions();
     actions.delete_service_settings(&auth_eg, &host).await?;
 
     Ok(HttpResponse::Ok().finish())

--- a/crates/cloud/src/test_utils.rs
+++ b/crates/cloud/src/test_utils.rs
@@ -128,7 +128,7 @@ impl TestSetupBuilder {
             } = fixture;
 
             let auth_eu = auth::EditUser::test(owner.clone());
-            let actions: ProjectActions = app_data.clone().into();
+            let actions: ProjectActions = app_data.to_project_actions();
             let project_data = CreateProjectDataDict {
                 owner: Some(owner),
                 name,
@@ -325,8 +325,7 @@ pub(crate) mod project {
                 name: self.name.unwrap_or("my project".into()),
                 collaborators: self.collaborators,
                 roles: self.roles,
-                save_state: api::SaveState::Saved,
-
+                //save_state: api::SaveState::Saved,
                 traces: self.traces,
             }
         }
@@ -338,7 +337,7 @@ pub(crate) mod project {
         pub(crate) owner: String,
         pub(crate) name: String,
         pub(crate) collaborators: std::vec::Vec<String>,
-        pub(crate) save_state: api::SaveState,
+        //pub(crate) save_state: api::SaveState,
         pub(crate) roles: HashMap<RoleId, RoleData>,
         pub(crate) traces: Vec<NetworkTraceMetadata>,
     }

--- a/crates/cloud/src/test_utils.rs
+++ b/crates/cloud/src/test_utils.rs
@@ -128,7 +128,7 @@ impl TestSetupBuilder {
             } = fixture;
 
             let auth_eu = auth::EditUser::test(owner.clone());
-            let actions: ProjectActions = app_data.to_project_actions();
+            let actions: ProjectActions = app_data.as_project_actions();
             let project_data = CreateProjectDataDict {
                 owner: Some(owner),
                 name,

--- a/crates/cloud/src/users/actions.rs
+++ b/crates/cloud/src/users/actions.rs
@@ -26,46 +26,46 @@ use crate::{
 
 use super::{email_template, strategies};
 
-pub(crate) struct UserActions {
-    users: Collection<User>,
-    banned_accounts: Collection<BannedAccount>,
-    password_tokens: Collection<SetPasswordToken>,
-    metrics: metrics::Metrics,
+pub(crate) struct UserActions<'a> {
+    users: &'a Collection<User>,
+    banned_accounts: &'a Collection<BannedAccount>,
+    password_tokens: &'a Collection<SetPasswordToken>,
+    metrics: &'a metrics::Metrics,
 
-    project_metadata: Collection<ProjectMetadata>,
-    project_cache: Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
-    network: Addr<TopologyActor>,
+    project_metadata: &'a Collection<ProjectMetadata>,
+    project_cache: &'a Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
+    network: &'a Addr<TopologyActor>,
 
-    friend_cache: Arc<RwLock<LruCache<String, Vec<String>>>>,
+    friend_cache: &'a Arc<RwLock<LruCache<String, Vec<String>>>>,
 
     // email support
-    mailer: SmtpTransport,
-    sender: Mailbox,
-    public_url: String,
+    mailer: &'a SmtpTransport,
+    sender: &'a Mailbox,
+    public_url: &'a String,
 }
 
 /// A struct for passing data to the constructor of `UserActions` w/o either 1) making
 /// all fields public on UserActions or 2) having *way* too many arguments
-pub(crate) struct UserActionData {
-    pub(crate) users: Collection<User>,
-    pub(crate) banned_accounts: Collection<BannedAccount>,
-    pub(crate) password_tokens: Collection<SetPasswordToken>,
-    pub(crate) metrics: metrics::Metrics,
+pub(crate) struct UserActionData<'a> {
+    pub(crate) users: &'a Collection<User>,
+    pub(crate) banned_accounts: &'a Collection<BannedAccount>,
+    pub(crate) password_tokens: &'a Collection<SetPasswordToken>,
+    pub(crate) metrics: &'a metrics::Metrics,
 
-    pub(crate) project_metadata: Collection<ProjectMetadata>,
-    pub(crate) project_cache: Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
-    pub(crate) network: Addr<TopologyActor>,
+    pub(crate) project_metadata: &'a Collection<ProjectMetadata>,
+    pub(crate) project_cache: &'a Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
+    pub(crate) network: &'a Addr<TopologyActor>,
 
-    pub(crate) friend_cache: Arc<RwLock<LruCache<String, Vec<String>>>>,
+    pub(crate) friend_cache: &'a Arc<RwLock<LruCache<String, Vec<String>>>>,
 
     // email support
-    pub(crate) mailer: SmtpTransport,
-    pub(crate) sender: Mailbox,
-    pub(crate) public_url: String,
+    pub(crate) mailer: &'a SmtpTransport,
+    pub(crate) sender: &'a Mailbox,
+    pub(crate) public_url: &'a String,
 }
 
-impl UserActions {
-    pub(crate) fn new(data: UserActionData) -> Self {
+impl<'a> UserActions<'a> {
+    pub(crate) fn new(data: UserActionData<'a>) -> Self {
         UserActions {
             users: data.users,
             banned_accounts: data.banned_accounts,

--- a/crates/cloud/src/users/routes.rs
+++ b/crates/cloud/src/users/routes.rs
@@ -17,7 +17,7 @@ use serde::Deserialize;
 async fn list_users(app: web::Data<AppData>, req: HttpRequest) -> Result<HttpResponse, UserError> {
     let auth_lu = auth::try_list_users(&app, &req).await?;
 
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     let users = actions.list_users(&auth_lu).await?;
 
     Ok(HttpResponse::Ok().json(users))
@@ -38,7 +38,7 @@ async fn create_user(
     // TODO: add more security features. Maybe activate accounts?
 
     let auth_cu = auth::try_create_user(&app, &req, user_data.into_inner()).await?;
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     let user = actions.create_user(auth_cu).await?;
 
     Ok(HttpResponse::Ok().json(user))
@@ -58,7 +58,7 @@ async fn login(
 
     let request = request.into_inner();
 
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     let user = actions.login(request).await?;
 
     session.insert("username", &user.username).unwrap();
@@ -83,7 +83,7 @@ async fn logout(
 
     if let Some(client_id) = &params.client_id {
         // FIXME: this method should be updated as it currently could be used to half logout other users...
-        let actions: UserActions = app.to_user_actions();
+        let actions: UserActions = app.as_user_actions();
         actions.logout(&client_id);
     }
 
@@ -108,7 +108,7 @@ async fn ban_user(
     let (username,) = path.into_inner();
     let auth_bu = auth::try_ban_user(&app, &req, &username).await?;
 
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     let account = actions.ban_user(&auth_bu).await?;
 
     Ok(HttpResponse::Ok().json(account))
@@ -123,7 +123,7 @@ async fn unban_user(
     let (username,) = path.into_inner();
     let auth_bu = auth::try_ban_user(&app, &req, &username).await?;
 
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     let account = actions.unban_user(&auth_bu).await?;
 
     Ok(HttpResponse::Ok().json(account))
@@ -139,7 +139,7 @@ async fn delete_user(
 
     let auth_eu = auth::try_edit_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     let user = actions.delete_user(&auth_eu).await?;
 
     Ok(HttpResponse::Ok().json(user))
@@ -159,7 +159,7 @@ async fn reset_password(
     let (username,) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     actions.reset_password(&auth_eu).await?;
 
     Ok(HttpResponse::Ok().finish())
@@ -193,7 +193,7 @@ async fn change_password(
     let (username,) = path.into_inner();
 
     let auth_sp = auth::try_set_password(&app, &req, &username, params.into_inner().token).await?;
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     let user = actions.set_password(&auth_sp, data.into_inner()).await?;
 
     Ok(HttpResponse::Ok().json(user))
@@ -208,7 +208,7 @@ async fn view_user(
     let (username,) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     let user = actions.get_user(&auth_vu).await?;
 
     Ok(HttpResponse::Ok().json(user))
@@ -226,7 +226,7 @@ async fn link_account(
     let creds = creds.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     let user = actions.link_account(&auth_eu, creds).await?;
 
     Ok(HttpResponse::Ok().json(user))
@@ -242,7 +242,7 @@ async fn unlink_account(
     let (username,) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.to_user_actions();
+    let actions: UserActions = app.as_user_actions();
     let user = actions
         .unlink_account(&auth_eu, account.into_inner())
         .await?;

--- a/crates/cloud/src/users/routes.rs
+++ b/crates/cloud/src/users/routes.rs
@@ -17,7 +17,7 @@ use serde::Deserialize;
 async fn list_users(app: web::Data<AppData>, req: HttpRequest) -> Result<HttpResponse, UserError> {
     let auth_lu = auth::try_list_users(&app, &req).await?;
 
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     let users = actions.list_users(&auth_lu).await?;
 
     Ok(HttpResponse::Ok().json(users))
@@ -38,7 +38,7 @@ async fn create_user(
     // TODO: add more security features. Maybe activate accounts?
 
     let auth_cu = auth::try_create_user(&app, &req, user_data.into_inner()).await?;
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     let user = actions.create_user(auth_cu).await?;
 
     Ok(HttpResponse::Ok().json(user))
@@ -58,7 +58,7 @@ async fn login(
 
     let request = request.into_inner();
 
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     let user = actions.login(request).await?;
 
     session.insert("username", &user.username).unwrap();
@@ -83,7 +83,7 @@ async fn logout(
 
     if let Some(client_id) = &params.client_id {
         // FIXME: this method should be updated as it currently could be used to half logout other users...
-        let actions: UserActions = app.into();
+        let actions: UserActions = app.to_user_actions();
         actions.logout(&client_id);
     }
 
@@ -108,7 +108,7 @@ async fn ban_user(
     let (username,) = path.into_inner();
     let auth_bu = auth::try_ban_user(&app, &req, &username).await?;
 
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     let account = actions.ban_user(&auth_bu).await?;
 
     Ok(HttpResponse::Ok().json(account))
@@ -123,7 +123,7 @@ async fn unban_user(
     let (username,) = path.into_inner();
     let auth_bu = auth::try_ban_user(&app, &req, &username).await?;
 
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     let account = actions.unban_user(&auth_bu).await?;
 
     Ok(HttpResponse::Ok().json(account))
@@ -139,7 +139,7 @@ async fn delete_user(
 
     let auth_eu = auth::try_edit_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     let user = actions.delete_user(&auth_eu).await?;
 
     Ok(HttpResponse::Ok().json(user))
@@ -159,7 +159,7 @@ async fn reset_password(
     let (username,) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     actions.reset_password(&auth_eu).await?;
 
     Ok(HttpResponse::Ok().finish())
@@ -193,7 +193,7 @@ async fn change_password(
     let (username,) = path.into_inner();
 
     let auth_sp = auth::try_set_password(&app, &req, &username, params.into_inner().token).await?;
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     let user = actions.set_password(&auth_sp, data.into_inner()).await?;
 
     Ok(HttpResponse::Ok().json(user))
@@ -208,7 +208,7 @@ async fn view_user(
     let (username,) = path.into_inner();
     let auth_vu = auth::try_view_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     let user = actions.get_user(&auth_vu).await?;
 
     Ok(HttpResponse::Ok().json(user))
@@ -226,7 +226,7 @@ async fn link_account(
     let creds = creds.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     let user = actions.link_account(&auth_eu, creds).await?;
 
     Ok(HttpResponse::Ok().json(user))
@@ -242,7 +242,7 @@ async fn unlink_account(
     let (username,) = path.into_inner();
     let auth_eu = auth::try_edit_user(&app, &req, None, &username).await?;
 
-    let actions: UserActions = app.into();
+    let actions: UserActions = app.to_user_actions();
     let user = actions
         .unlink_account(&auth_eu, account.into_inner())
         .await?;


### PR DESCRIPTION
This PR updates the actions for the different resources (users, friends, libraries, projects, etc) using references to data in AppData rather than having a bunch of `clone` calls.