### PR TITLE
Make user banning idempotent

### DIFF
--- a/crates/cloud/src/auth/users.rs
+++ b/crates/cloud/src/auth/users.rs
@@ -56,6 +56,16 @@ impl EditUser {
 }
 
 #[cfg(test)]
+impl BanUser {
+    pub(crate) fn test(username: String) -> Self {
+        Self {
+            username,
+            _private: (),
+        }
+    }
+}
+
+#[cfg(test)]
 impl ViewUser {
     pub(crate) fn test(username: String) -> Self {
         Self {


### PR DESCRIPTION
Currently, banning a user makes multiple records in the database resulting in needing multiple `unban` calls to revert.