### PR TITLE
Add endpoints for fetching project xml by name or ID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
           RUSTTARGET: ${{ matrix.target }}
           ARCHIVE_TYPES: ${{ matrix.archive }}
           SRC_DIR: crates/cli
+          TOOLCHAIN_VERSION: 1.73
           ARCHIVE_NAME: netsblox_cli_${{ github.event.release.name }}_${{ matrix.target }}
       - name: Build NetsBlox Cloud
         uses: rust-build/rust-build.action@v1.4.0
@@ -36,6 +37,7 @@ jobs:
         with:
           RUSTTARGET: ${{ matrix.target }}
           ARCHIVE_TYPES: ${{ matrix.archive }}
+          TOOLCHAIN_VERSION: 1.73
           SRC_DIR: crates/cloud
           ARCHIVE_NAME: netsblox_cloud_${{ github.event.release.name }}_${{ matrix.target }}
       - name: Publish (to crates.io)

--- a/crates/cloud/src/projects/routes.rs
+++ b/crates/cloud/src/projects/routes.rs
@@ -821,7 +821,7 @@ mod tests {
 
                 let cookie = test_utils::cookie::new(&user.username);
                 let req = test::TestRequest::get()
-                    .uri(&format!("/user/{}/{}/xml", &project.owner, &project.name))
+                    .uri(&format!("/user/{}/{}", &project.owner, &project.name))
                     .cookie(cookie)
                     .to_request();
 


### PR DESCRIPTION
- Update rust toolchain to v1.73
- Add endpoints for fetching project xml directly
