### PR TITLE
log error if unable to compute unix timestamp

### DIFF
--- a/crates/cloud/src/network/topology/network.rs
+++ b/crates/cloud/src/network/topology/network.rs
@@ -119,7 +119,7 @@ impl ProjectNetwork {
         let version = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .map(|dur| dur.as_secs())
-            .map(|err| {
+            .map_err(|err| {
                 log::error!("Unable to compute unix timestamp: {}", &err);
                 err
             })


### PR DESCRIPTION
Incorrectly logging that an error occurred