### PR TITLE
Replace while loop with iter w/ explicit attempt range

### DIFF
--- a/crates/cloud/src/errors.rs
+++ b/crates/cloud/src/errors.rs
@@ -67,12 +67,18 @@ pub enum UserError {
     BannedUserError,
     #[display(fmt = "User already exists.")]
     UserExistsError,
+    // FIXME: use a different status code or something so the client can
+    // handle it another way
+    #[display(fmt = "Username already exists. Please try again with a different name.")]
+    UsernameExists,
     #[display(fmt = "Group already exists.")]
     GroupExistsError,
     #[display(fmt = "Invalid username.")]
     InvalidUsername,
     #[display(fmt = "Invalid name.")]
     InvalidRoleOrProjectName,
+    #[display(fmt = "Name already exists. Please rename and try again.")]
+    RoleOrProjectNameExists,
     #[display(fmt = "Invalid library name.")]
     InvalidLibraryName,
     #[display(fmt = "Invalid email address.")]
@@ -182,6 +188,7 @@ impl error::ResponseError for UserError {
             Self::InternalError | Self::SnapConnectionError => StatusCode::INTERNAL_SERVER_ERROR,
             Self::InvalidUsername
             | Self::InvalidRoleOrProjectName
+            | Self::RoleOrProjectNameExists
             | Self::InvalidEmailAddress
             | Self::InvalidClientIdError
             | Self::InvalidLibraryName
@@ -193,6 +200,7 @@ impl error::ResponseError for UserError {
             | Self::TorAddressError
             | Self::OperaVPNError
             | Self::UserExistsError
+            | Self::UsernameExists
             | Self::OAuthClientAlreadyExistsError
             | Self::GroupExistsError
             | Self::CannotDeleteLastRoleError

--- a/crates/cloud/src/projects/actions.rs
+++ b/crates/cloud/src/projects/actions.rs
@@ -442,14 +442,9 @@ impl<'a> ProjectActions<'a> {
             .return_document(ReturnDocument::After)
             .build();
 
-        let role_names = ep
-            .metadata
-            .roles
-            .values()
-            .map(|r| r.name.to_owned())
-            .collect::<Vec<_>>();
+        let role_names = ep.metadata.roles.values().map(|r| r.name.as_str());
 
-        let role_name = utils::get_unique_name(role_names, &role_md.name);
+        let role_name = utils::get_unique_name(role_names, &role_md.name)?;
         role_md.name = role_name;
 
         let query = doc! {"id": &ep.metadata.id};


### PR DESCRIPTION
The incremented variable in the while loop could overflow and result in an
infinite loop if there were more than 255 projects with the same name. This
increases the limit to 1k and returns an error if the attempts fail (rather than
creating an infinite loop).

It's worth mentioning that this is due to the lack of runtime overflow checks
when building in release mode.
