### PR TITLE
Use project actions to cleanup empty transient projects

### DIFF
--- a/crates/cloud/src/auth/mod.rs
+++ b/crates/cloud/src/auth/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod libraries;
 pub(crate) mod network;
 pub(crate) mod oauth;
 pub(crate) mod projects;
+pub(crate) mod system;
 pub(crate) mod users;
 
 pub(crate) use crate::auth::collaboration::*;
@@ -14,6 +15,7 @@ pub(crate) use crate::auth::libraries::*;
 pub(crate) use crate::auth::network::*;
 pub(crate) use crate::auth::oauth::*;
 pub(crate) use crate::auth::projects::*;
+pub(crate) use crate::auth::system::*;
 pub(crate) use crate::auth::users::*;
 
 use crate::app_data::AppData;

--- a/crates/cloud/src/auth/projects.rs
+++ b/crates/cloud/src/auth/projects.rs
@@ -7,7 +7,7 @@ use crate::app_data::AppData;
 use crate::errors::UserError;
 use crate::utils;
 
-use super::is_moderator;
+use super::{is_moderator, ManageSystem};
 
 /// Permissions to view a specific project
 pub(crate) struct ViewProject {
@@ -28,43 +28,20 @@ pub(crate) struct EditProject {
 }
 
 pub(crate) struct DeleteProject {
-    pub(crate) metadata: ProjectMetadata,
+    pub(crate) id: api::ProjectId,
     _private: (),
 }
 
-/// Permissions to approve projects that trigger manual approval
+impl DeleteProject {
+    /// Get project deletion permissions from system management permissions.
+    pub(crate) fn from_manage_system(_witness: &ManageSystem, id: api::ProjectId) -> Self {
+        Self { id, _private: () }
+    }
+}
+
+/// Permissions to approve projects that require manual approval
 pub(crate) struct ModerateProjects {
     _private: (),
-}
-
-#[cfg(test)]
-impl ViewProject {
-    pub(crate) fn test(metadata: ProjectMetadata) -> Self {
-        Self {
-            metadata,
-            _private: (),
-        }
-    }
-}
-
-#[cfg(test)]
-impl DeleteProject {
-    pub(crate) fn test(metadata: ProjectMetadata) -> Self {
-        Self {
-            metadata,
-            _private: (),
-        }
-    }
-}
-
-#[cfg(test)]
-impl EditProject {
-    pub(crate) fn test(metadata: ProjectMetadata) -> Self {
-        Self {
-            metadata,
-            _private: (),
-        }
-    }
 }
 
 pub(crate) async fn try_view_project(
@@ -146,7 +123,7 @@ pub(crate) async fn try_delete_project(
     super::try_edit_user(app, req, client_id.as_ref(), &metadata.owner)
         .await
         .map(|_eu| DeleteProject {
-            metadata,
+            id: metadata.id,
             _private: (),
         })
 }
@@ -210,5 +187,70 @@ fn flatten<T>(nested: Option<Option<T>>) -> Option<T> {
     match nested {
         Some(x) => x,
         None => None,
+    }
+}
+
+#[cfg(test)]
+mod test_utils {
+    use super::*;
+
+    impl ViewProject {
+        pub(crate) fn test(metadata: ProjectMetadata) -> Self {
+            Self {
+                metadata,
+                _private: (),
+            }
+        }
+    }
+
+    impl DeleteProject {
+        pub(crate) fn test(metadata: ProjectMetadata) -> Self {
+            Self {
+                id: metadata.id,
+                _private: (),
+            }
+        }
+    }
+
+    impl EditProject {
+        pub(crate) fn test(metadata: ProjectMetadata) -> Self {
+            Self {
+                metadata,
+                _private: (),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[actix_web::test]
+    #[ignore]
+    async fn test_try_view_project_owner() {
+        todo!();
+    }
+
+    #[actix_web::test]
+    #[ignore]
+    async fn test_try_view_project_invited() {
+        todo!();
+    }
+
+    #[actix_web::test]
+    #[ignore]
+    async fn test_try_view_project_group_owner() {
+        todo!();
+    }
+
+    #[actix_web::test]
+    #[ignore]
+    async fn test_try_view_project_admin() {
+        todo!();
+    }
+
+    #[actix_web::test]
+    #[ignore]
+    async fn test_try_view_project_403() {
+        todo!();
     }
 }

--- a/crates/cloud/src/auth/system.rs
+++ b/crates/cloud/src/auth/system.rs
@@ -1,0 +1,15 @@
+use crate::network::topology::network;
+
+/// This is used to get "system" permissions used when the network topology needs
+/// to perform actions. It is not intended to be used directly but, rather, to be
+/// able to be converted to other concrete authorizations
+
+pub(crate) struct ManageSystem {
+    _private: (),
+}
+
+/// Get permissions to manage the system. Only the network topology can obtain these
+/// permissions.
+pub(crate) fn try_manage_system(_network: &network::Topology) -> ManageSystem {
+    ManageSystem { _private: () }
+}

--- a/crates/cloud/src/network/topology/mod.rs
+++ b/crates/cloud/src/network/topology/mod.rs
@@ -1,6 +1,6 @@
 mod address;
 mod client;
-mod network;
+pub(crate) mod network;
 
 use crate::app_data::AppData;
 use crate::common::api::{ClientId, ExternalClient, ProjectId, RoleData, RoomState};

--- a/crates/cloud/src/projects/actions.rs
+++ b/crates/cloud/src/projects/actions.rs
@@ -615,7 +615,7 @@ impl<'a> ProjectActions<'a> {
         &self,
         dp: &auth::projects::DeleteProject,
     ) -> Result<api::ProjectMetadata, UserError> {
-        let query = doc! {"id": &dp.metadata.id};
+        let query = doc! {"id": &dp.id};
         let metadata = self
             .project_metadata
             .find_one_and_delete(query, None)


### PR DESCRIPTION
Currently, cleaned up transient projects only delete the metadata from the
database. Since they don't use the official `delete_project` method, they don't
do a few things including:

- delete content from s3
- clear the project cache

The same is true of projects deleted automatically by MongoDB using the
`deleteAt` field. This index should be removed and deletion should be handled by
the system to ensure the aforementioned issues don't emerge there, too.
