### PR TITLE
Remove `unwrap` calls when accessing project cache

### DIFF
--- a/crates/cloud/src/projects/actions.rs
+++ b/crates/cloud/src/projects/actions.rs
@@ -226,6 +226,7 @@ impl<'a> ProjectActions<'a> {
                 .write_image(image.as_bytes(), resized_width, resized_height, color)
                 .map_err(InternalError::ThumbnailEncodeError)?;
             actix_web::web::Bytes::copy_from_slice(&png_bytes.into_inner().unwrap())
+        // FIXME: remove unwrap?
         } else {
             let (width, height) = thumbnail.dimensions();
             let mut png_bytes = BufWriter::new(Vec::new());
@@ -235,6 +236,7 @@ impl<'a> ProjectActions<'a> {
                 .write_image(thumbnail.as_bytes(), width, height, color)
                 .map_err(InternalError::ThumbnailEncodeError)?;
             actix_web::web::Bytes::copy_from_slice(&png_bytes.into_inner().unwrap())
+            // FIXME: remove unwrap?
         };
 
         Ok(image_content)
@@ -634,8 +636,11 @@ impl<'a> ProjectActions<'a> {
             .into_iter()
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut cache = self.project_cache.write().unwrap();
-        cache.pop(&metadata.id);
+        if let Ok(mut cache) = self.project_cache.write() {
+            cache.pop(&metadata.id);
+        } else {
+            log::error!("Unable to acquire project cache lock to clear project.");
+        }
 
         self.network
             .do_send(topology::ProjectDeleted::new(metadata.clone()));

--- a/crates/cloud/src/utils.rs
+++ b/crates/cloud/src/utils.rs
@@ -41,21 +41,25 @@ pub(crate) fn update_project_cache(
     cache: &Arc<RwLock<LruCache<api::ProjectId, ProjectMetadata>>>,
     metadata: ProjectMetadata,
 ) -> ProjectMetadata {
-    let mut cache = cache.write().unwrap();
-    let latest = cache
-        .get(&metadata.id)
-        .and_then(|existing| {
-            if existing.updated > metadata.updated {
-                Some(existing.to_owned())
-            } else {
-                None
-            }
-        })
-        .unwrap_or(metadata);
+    if let Ok(mut cache) = cache.write() {
+        let latest = cache
+            .get(&metadata.id)
+            .and_then(|existing| {
+                if existing.updated > metadata.updated {
+                    Some(existing.to_owned())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(metadata);
 
-    cache.put(latest.id.clone(), latest.clone());
+        cache.put(latest.id.clone(), latest.clone());
 
-    latest
+        latest
+    } else {
+        log::warn!("Unable to acquire project cache to update project");
+        metadata
+    }
 }
 
 /// Get a unique project name for the given user and preferred name.


### PR DESCRIPTION
This PR currently just logs failures. However, this is probably not really ideal
since this effectively means that if the `write()` call fails (due to a panic
occurring while the lock was previously held), the server essentially continues
operation without any project cache.

This isn't great since that would hinder performance until the server is
restarted. It would be better if the cache was reset if the lock has been
poisoned.
