### PR TITLE
Set updated field on activate project

### DIFF
--- a/crates/cloud/src/network/actions.rs
+++ b/crates/cloud/src/network/actions.rs
@@ -69,7 +69,8 @@ impl<'a> NetworkActions<'a> {
         };
         let update = doc! {
             "$set": {
-                "saveState": SaveState::Transient
+                "saveState": SaveState::Transient,
+                "updated": DateTime::now(),
             },
             "$unset": {
                 "deleteAt": 1

--- a/crates/cloud/src/network/actions.rs
+++ b/crates/cloud/src/network/actions.rs
@@ -85,7 +85,6 @@ impl<'a> NetworkActions<'a> {
             .await
             .map_err(InternalError::DatabaseConnectionError)?;
 
-        dbg!(&metadata);
         if let Some(metadata) = metadata {
             utils::update_project_cache(self.project_cache, metadata);
         }


### PR DESCRIPTION
- Remove old debug log
- set the `updated` field on activate network
