### PR TITLE
Add netsblox_macros (for Witness macro)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["crates/cloud", "crates/cli", "crates/api", "crates/api-common", "crates/cloud-common", "crates/migrate"]
+members = ["crates/cloud", "crates/cli", "crates/api", "crates/api-common", "crates/cloud-common", "crates/migrate", "crates/macros"]

--- a/crates/cloud/Cargo.toml
+++ b/crates/cloud/Cargo.toml
@@ -44,3 +44,4 @@ aws-sdk-s3 = "0.31.2"
 aws-credential-types = "0.56.1"
 aws-config = "0.56.1"
 nonempty = "0.9.0"
+netsblox-macros = { path = "../macros", version = "1.0.0" }

--- a/crates/cloud/src/auth/hosts.rs
+++ b/crates/cloud/src/auth/hosts.rs
@@ -2,7 +2,9 @@ use super::is_super_user;
 use crate::app_data::AppData;
 use crate::errors::UserError;
 use actix_web::HttpRequest;
+use netsblox_macros::Witness;
 
+#[derive(Witness)] // FIXME: this doesn't work
 pub(crate) struct ViewAuthHosts {
     _private: (),
 }

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "netsblox-macros"
+version = "1.0.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0.35"
+syn = "2.0.48"

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -1,0 +1,33 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(Witness)]
+pub fn derive_witness(input: TokenStream) -> TokenStream {
+    let DeriveInput { ident, attrs, .. } = parse_macro_input!(input);
+    // TODO: add _private field to struct
+    let output = quote! {
+        impl #ident {
+            #[cfg(test)]
+            pub(crate) fn test() -> Self {
+                // TODO: get the inputs and pass them through
+                Self {
+                    _private: ()
+                }
+            }
+        }
+    };
+
+    output.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
WIP add macro so you can do things like
```rust
#[derive(Witness)]
pub(crate) struct EditGallery {
  pub(crate) gallery: Gallery,
}
```
and it should be only able to be instantiated in that module (except if `cfg(test)` in which case a factory method is exposed).
